### PR TITLE
Add a cron job to prune old containers

### DIFF
--- a/modules/aws_asg/bats_helpers.bash
+++ b/modules/aws_asg/bats_helpers.bash
@@ -6,6 +6,7 @@ aws_asg_setup() {
   export VARTMP="${BATS_TMPDIR}/var/tmp"
   export MOCKLOG="${BATS_TMPDIR}/logs/mock.log"
   export KILL_COMMAND="${BATS_TMPDIR}/bin/kill_mocked"
+  export CREDS_FILE="/dev/null"
 
   mkdir -p \
     "${RUNDIR}" \
@@ -49,6 +50,7 @@ EOF
   for cmd in \
     awk \
     chown \
+    curl \
     dmesg \
     date \
     docker \

--- a/modules/aws_asg/check-docker-health-crontab
+++ b/modules/aws_asg/check-docker-health-crontab
@@ -1,3 +1,3 @@
 SHELL = /bin/bash
 
-* * * * * root /var/tmp/travis-run.d/check-docker-health >> /var/log/syslog
+* * * * * root /var/tmp/travis-run.d/check-docker-health &>> /var/log/syslog

--- a/modules/aws_asg/cloud-config.yml.tpl
+++ b/modules/aws_asg/cloud-config.yml.tpl
@@ -76,6 +76,16 @@ write_files:
   owner: 'root:root'
   path: /etc/cron.d/check-docker-health-crontab
   permissions: '0644'
+- content: '${base64encode(file("${here}/kill-old-containers.bash"))}'
+  encoding: b64
+  owner: 'root:root'
+  path: /var/tmp/travis-run.d/kill-old-containers
+  permissions: '0750'
+- content: '${base64encode(file("${here}/kill-old-containers-crontab"))}'
+  encoding: b64
+  owner: 'root:root'
+  path: /etc/cron.d/kill-old-containers-crontab
+  permissions: '0644'
 - content: '${base64encode(file("${assets}/travis-worker/travis-worker.service"))}'
   encoding: b64
   owner: 'root:root'

--- a/modules/aws_asg/kill-old-containers-crontab
+++ b/modules/aws_asg/kill-old-containers-crontab
@@ -1,3 +1,3 @@
 SHELL = /bin/bash
 
-* * * * * root /var/tmp/travis-run.d/kill-old-containers >> /var/log/syslog
+* * * * * root /var/tmp/travis-run.d/kill-old-containers &>> /var/log/syslog

--- a/modules/aws_asg/kill-old-containers-crontab
+++ b/modules/aws_asg/kill-old-containers-crontab
@@ -1,3 +1,3 @@
 SHELL = /bin/bash
 
-* * * * * root /var/tmp/travis-run.d/kill-old-containers &>> /var/log/syslog
+* * * * * root /var/tmp/travis-run.d/kill-old-containers >> /var/log/syslog

--- a/modules/aws_asg/kill-old-containers-crontab
+++ b/modules/aws_asg/kill-old-containers-crontab
@@ -1,0 +1,3 @@
+SHELL = /bin/bash
+
+* * * * * root /var/tmp/travis-run.d/kill-old-containers >> /var/log/syslog

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -20,7 +20,8 @@ __report_kills() {
 
   # request_body=$(< <(cat <<EOF)
   # read -r -d '' request_body <<EOF
-  request_body=$(cat <<EOF
+  request_body=$(
+    cat <<EOF
   { "measure_time": "$timestamp",
     "source": "cron.ec2.aj.container-killer",
     "gauges": [

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -17,21 +17,27 @@ __report_kills() {
   count_killed="$1"
   count_not_killed="$2"
   timestamp="$(date +%s)"
+  site="$TRAVIS_WORKER_TRAVIS_SITE"
+  stage="staging"
+  if [[ "$HOSTNAME" == *"production"* ]]; then
+    stage="production"
+  fi
+
 
   # request_body=$(< <(cat <<EOF)
   # read -r -d '' request_body <<EOF
   request_body=$(
     cat <<EOF
   { "measure_time": "$timestamp",
-    "source": "cron.ec2.aj.container-killer",
+    "source": "cron.ec2.$site.$stage.aj-container-killer",
     "gauges": [
       {
-        "name": "cron.containers.killed",
+        "name": "cron.containers.killed.$site.$stage",
         "value": "$count_killed",
         "source": "$instance_id"
       },
       {
-        "name": "cron.containers.not-killed",
+        "name": "cron.containers.not-killed.$site.$stage",
         "value": "$count_not_killed",
         "source": "$instance_id"
       }

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -63,6 +63,7 @@ main() {
   # shellcheck disable=SC2153
   : "${MAX_AGE:=10800}"
   : "${CREDS_FILE:=/etc/default/travis-worker}"
+  # shellcheck disable=SC1090
   source "${CREDS_FILE}"
   : "${LIBRATO_API:=https://metrics-api.librato.com}"
   : "${LIBRATO_USERNAME:=${TRAVIS_WORKER_LIBRATO_EMAIL}}"
@@ -80,12 +81,12 @@ main() {
 
   if [ -z "${LIBRATO_CREDENTIALS}" ]; then
     logger "No Librato credentials defined, aborting"
-    __die "error" 0 0 0
+    __die "error" 1 0 0
   fi
 
   if [ -z "$cids" ]; then
     logger "No containers running, aborting"
-    __die "error" 0 0 0
+    __die "warning" 0 0 0
   fi
 
   for cid in $cids; do

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -17,6 +17,7 @@ __container_is_newer_than() {
   created=$(date --date="$(docker inspect -f '{{ .Created }}' "$cid")" +%s)
   age=$(($(date +%s) - created))
   if [ "$age" -gt "$max_age" ]; then
+    logger "Container $cid age $age is older than max_age of $max_age."
     return 1
   fi
 }
@@ -38,7 +39,7 @@ main() {
     if [[ "$(docker inspect "$cid" --format '{{ .Name }}')" == "/travis-worker" ]]; then
       continue
     fi
-    if [[ ! $(__container_is_newer_than "$cid" "$max_age") ]]; then
+    if ! __container_is_newer_than "$cid" "$max_age"; then
       name="$(docker inspect "$cid" --format '{{ .Name }}')"
       logger "$cid is older than $max_age; killing it! ($name)"
       docker kill "$cid"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -1,14 +1,28 @@
 #!/bin/bash
 set -e
 
+__die() {
+  local status="${1}"
+  local code="${2}"
+  local count="${3}"
+  logger "time=$(date -u +%Y%m%dT%H%M%S) " \
+    "prog=$(basename "${0}") status=${status} count=${count}"
+  exit "${code}"
+}
+
 main() {
   worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
   cids=$(docker ps -q --filter before="$worker_cid")
+
+  if [ -z "$cids" ]; then
+    __die noop 0 0
+  fi
 
   for cid in $cids; do
     logger "Removing container older than travis-worker: $(docker ps --filter id="$cid" | grep -v CONTAINER)"
     docker kill "$cid"
   done
+  __die killed 0 "$(echo "$cids" | wc -l)"
 }
 
 main "$@"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -23,7 +23,6 @@ __report_kills() {
     stage="production"
   fi
 
-
   # request_body=$(< <(cat <<EOF)
   # read -r -d '' request_body <<EOF
   request_body=$(
@@ -67,7 +66,7 @@ __container_is_newer_than() {
 
 main() {
   # shellcheck disable=SC2153
-  : "${MAX_AGE:=12000}"
+  : "${MAX_AGE:=10800}"
   : "${CREDS_FILE:=/etc/default/travis-worker}"
   # shellcheck disable=SC1090
   source "${CREDS_FILE}"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -12,9 +12,8 @@ __die() {
 }
 
 main() {
-  local worker_cid cids
-  worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
-  cids=$(docker ps -q --filter before="$worker_cid")
+  local worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
+  local cids=$(docker ps -q --filter before="$worker_cid")
 
   if [ -z "$cids" ]; then
     __die noop 0 0

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+for cid in $(docker ps -q); do
+  now=$(date +%s)
+
+  created_at=$(date -d "$(docker inspect --format '{{.Created}}' "$cid")" +%s)
+  cutoff=$(echo "$(date +%s)-60*120" | bc)
+  ttl=$((created_at - cutoff))
+  name="$(docker inspect "$cid" --format '{{ .Name }}')"
+  age=$((now - created_at))
+
+  if [ $ttl -lt 0 ]; then
+    if [[ "$name" == "/travis-worker" ]]; then
+      echo " [OK] travis-worker"
+      continue
+    fi
+    echo "[NOK] $cid: OLD! $(date -d@$age +%H:%M:%S) => $name"
+  else
+    echo " [OK] $cid: $(date -d@$ttl -u +%H:%M:%S) left => $name"
+  fi
+done

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -8,7 +8,7 @@ __die() {
   local killed_count="${3}"
   local not_killed_count="${4}"
   logger "time=$(date -u +%Y%m%dT%H%M%S) " \
-    "prog=$(basename "${0}") status=${status} count=${killed_count} total=${not_killed_count}"
+    "prog=$(basename "${0}") status=${status} killed_count=${killed_count} not_killed_count=${not_killed_count}"
   __report_kills "$killed_count" "$not_killed_count"
   exit "${code}"
 }
@@ -57,9 +57,7 @@ __container_is_newer_than() {
 }
 
 main() {
-  # shellcheck disable=SC1091
-  source /etc/default/travis-worker
-
+  : "${CREDS_FILE:=/etc/default/travis-worker}"
   : "${LIBRATO_API:=https://metrics-api.librato.com}"
   : "${LIBRATO_USERNAME:=${TRAVIS_WORKER_LIBRATO_EMAIL}}"
   : "${LIBRATO_TOKEN:=${TRAVIS_WORKER_LIBRATO_TOKEN}}"
@@ -68,13 +66,12 @@ main() {
   : "${RUNDIR:=/var/tmp/travis-run.d}"
 
   local instance_id cids killed_count not_killed_count max_age
-  instance_id="$(cat "${RUNDIR}/instance-id")"
-
   # shellcheck disable=SC2153
   max_age="${MAX_AGE}"
   killed_count=0
   not_killed_count=0
   cids=$(docker ps -q)
+  instance_id="$(cat "${RUNDIR}/instance-id")"
 
   if [ -z "$cids" ]; then
     __die noop 0 0 0
@@ -83,6 +80,7 @@ main() {
   for cid in $cids; do
     # Don't kill travis-worker
     if [[ "$(docker inspect "$cid" --format '{{ .Name }}')" == "/travis-worker" ]]; then
+      not_killed_count="$((not_killed_count + 1))"
       continue
     fi
     if ! __container_is_newer_than "$cid" "$max_age"; then

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -5,10 +5,44 @@ set -o pipefail
 __die() {
   local status="${1}"
   local code="${2}"
-  local count="${3}"
+  local killed_count="${3}"
+  local not_killed_count="${4}"
   logger "time=$(date -u +%Y%m%dT%H%M%S) " \
-    "prog=$(basename "${0}") status=${status} count=${count}"
+    "prog=$(basename "${0}") status=${status} count=${killed_count} total=${not_killed_count}"
+  __report_kills "$killed_count" "$not_killed_count"
   exit "${code}"
+}
+
+__report_kills() {
+  count_killed="$1"
+  count_not_killed="$2"
+  timestamp="$(date +%s)"
+
+  request_body=$(< <(cat <<EOF
+  { "measure_time": "$timestamp",
+    "source": "cron.ec2.aj.container-killer",
+    "gauges": [
+      {
+        "name": "cron.containers.killed",
+        "value": "$count_killed",
+        "source": "$instance_id"
+      },
+      {
+        "name": "cron.containers.not-killed",
+        "value": "$count_not_killed",
+        "source": "$instance_id"
+      }
+    ]
+  }
+EOF
+  ))
+
+  curl \
+    -u "$LIBRATO_CREDENTIALS" \
+    -H "Content-Type: application/json" \
+    -d $"$request_body" \
+    -X POST \
+    "${LIBRATO_API}/v1/metrics"
 }
 
 __container_is_newer_than() {
@@ -23,15 +57,27 @@ __container_is_newer_than() {
 }
 
 main() {
-  local cids killed_count
-  # shellcheck disable=SC2153
-  local max_age="${MAX_AGE}"
+  # shellcheck disable=SC1091
+  source /etc/default/travis-worker
+
+  : "${LIBRATO_API:=https://metrics-api.librato.com}"
+  : "${LIBRATO_USERNAME:=${TRAVIS_WORKER_LIBRATO_EMAIL}}"
+  : "${LIBRATO_TOKEN:=${TRAVIS_WORKER_LIBRATO_TOKEN}}"
+  : "${LIBRATO_CREDENTIALS:=${LIBRATO_USERNAME}:${LIBRATO_TOKEN}}"
   : "${max_age:=10800}"
+  : "${RUNDIR:=/var/tmp/travis-run.d}"
+
+  local instance_id cids killed_count not_killed_count max_age
+  instance_id="$(cat "${RUNDIR}/instance-id")"
+
+  # shellcheck disable=SC2153
+  max_age="${MAX_AGE}"
   killed_count=0
+  not_killed_count=0
   cids=$(docker ps -q)
 
   if [ -z "$cids" ]; then
-    __die noop 0 0
+    __die noop 0 0 0
   fi
 
   for cid in $cids; do
@@ -44,9 +90,11 @@ main() {
       logger "$cid is older than $max_age; killing it! ($name)"
       docker kill "$cid"
       killed_count="$((killed_count + 1))"
+    else
+      not_killed_count="$((not_killed_count + 1))"
     fi
   done
-  __die killed 0 "$killed_count"
+  __die killed 0 "$killed_count" "$not_killed_count"
 }
 
 main "$@"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -67,7 +67,7 @@ __container_is_newer_than() {
 
 main() {
   # shellcheck disable=SC2153
-  : "${MAX_AGE:=10800}"
+  : "${MAX_AGE:=12000}"
   : "${CREDS_FILE:=/etc/default/travis-worker}"
   # shellcheck disable=SC1090
   source "${CREDS_FILE}"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -18,7 +18,9 @@ __report_kills() {
   count_not_killed="$2"
   timestamp="$(date +%s)"
 
-  request_body=$(< <(cat <<EOF
+  # request_body=$(< <(cat <<EOF)
+  # read -r -d '' request_body <<EOF
+  request_body=$(cat <<EOF
   { "measure_time": "$timestamp",
     "source": "cron.ec2.aj.container-killer",
     "gauges": [
@@ -35,7 +37,7 @@ __report_kills() {
     ]
   }
 EOF
-  ))
+  )
 
   curl \
     -u "$LIBRATO_CREDENTIALS" \
@@ -57,16 +59,16 @@ __container_is_newer_than() {
 }
 
 main() {
+  # shellcheck disable=SC2153
+  : "${MAX_AGE:=10800}"
   : "${CREDS_FILE:=/etc/default/travis-worker}"
   : "${LIBRATO_API:=https://metrics-api.librato.com}"
   : "${LIBRATO_USERNAME:=${TRAVIS_WORKER_LIBRATO_EMAIL}}"
   : "${LIBRATO_TOKEN:=${TRAVIS_WORKER_LIBRATO_TOKEN}}"
   : "${LIBRATO_CREDENTIALS:=${LIBRATO_USERNAME}:${LIBRATO_TOKEN}}"
-  : "${max_age:=10800}"
   : "${RUNDIR:=/var/tmp/travis-run.d}"
 
   local instance_id cids killed_count not_killed_count max_age
-  # shellcheck disable=SC2153
   max_age="${MAX_AGE}"
   killed_count=0
   not_killed_count=0

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -23,6 +23,7 @@ __container_is_newer_than() {
 
 main() {
   local cids killed_count
+  # shellcheck disable=SC2153
   local max_age="${MAX_AGE}"
   : "${max_age:=10800}"
   killed_count=0
@@ -39,7 +40,7 @@ main() {
     fi
     if [[ ! $(__container_is_newer_than "$cid" "$max_age") ]]; then
       name="$(docker inspect "$cid" --format '{{ .Name }}')"
-      logger "$cid is older than 10800s; killing it! ($name)"
+      logger "$cid is older than $max_age; killing it! ($name)"
       docker kill "$cid"
       killed_count="$((killed_count + 1))"
     fi

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -1,21 +1,14 @@
 #!/bin/bash
+set -e
 
-for cid in $(docker ps -q); do
-  now=$(date +%s)
+main() {
+  worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
+  cids=$(docker ps -q --filter before="$worker_cid")
 
-  created_at=$(date -d "$(docker inspect --format '{{.Created}}' "$cid")" +%s)
-  cutoff=$(echo "$(date +%s)-60*120" | bc)
-  ttl=$((created_at - cutoff))
-  name="$(docker inspect "$cid" --format '{{ .Name }}')"
-  age=$((now - created_at))
+  for cid in $cids; do
+    logger "Removing container older than travis-worker: $(docker ps --filter id="$cid" | grep -v CONTAINER)"
+    docker kill "$cid"
+  done
+}
 
-  if [ $ttl -lt 0 ]; then
-    if [[ "$name" == "/travis-worker" ]]; then
-      echo " [OK] travis-worker"
-      continue
-    fi
-    echo "[NOK] $cid: OLD! $(date -d@$age +%H:%M:%S) => $name"
-  else
-    echo " [OK] $cid: $(date -d@$ttl -u +%H:%M:%S) left => $name"
-  fi
-done
+main "$@"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -12,8 +12,9 @@ __die() {
 }
 
 main() {
-  local worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
-  local cids=$(docker ps -q --filter before="$worker_cid")
+  local worker_cid cids
+  worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
+  cids=$(docker ps -q --filter before="$worker_cid")
 
   if [ -z "$cids" ]; then
     __die noop 0 0

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 __die() {
   local status="${1}"

--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -12,6 +12,7 @@ __die() {
 }
 
 main() {
+  local worker_cid cids
   worker_cid=$(docker inspect travis-worker --format '{{ .Id }}')
   cids=$(docker ps -q --filter before="$worker_cid")
 

--- a/modules/aws_asg/kill-old-containers.bats
+++ b/modules/aws_asg/kill-old-containers.bats
@@ -3,7 +3,6 @@
 load bats_helpers
 
 setup() {
-  export CREDS_FILE=/dev/null
   aws_asg_setup
 }
 

--- a/modules/aws_asg/kill-old-containers.bats
+++ b/modules/aws_asg/kill-old-containers.bats
@@ -3,7 +3,7 @@
 load bats_helpers
 
 setup() {
-  export MAX_AGE=120
+  export MAX_AGE=10800
   aws_asg_setup
 }
 

--- a/modules/aws_asg/kill-old-containers.bats
+++ b/modules/aws_asg/kill-old-containers.bats
@@ -3,7 +3,7 @@
 load bats_helpers
 
 setup() {
-  export MAX_AGE=10800
+  export CREDS_FILE=/dev/null
   aws_asg_setup
 }
 
@@ -13,29 +13,6 @@ teardown() {
 
 run_kill_old_containers() {
   bash "${BATS_TEST_DIRNAME}/kill-old-containers.bash"
-}
-
-@test "removes containers older than 3 hours" {
-  cat >"${BATS_TMPDIR}/returns/docker" <<EOF
-4b4b1e76884b
-e2f6756f92d7
-75e342138b9e
-f2dc4be5a304
-9153fe19ef63
-32b7af38a72a
-098460f0b007
-76ca3e25d62a
-83a9c5a0eb61
-EOF
-
-  cat >"${BATS_TMPDIR}/returns/date" <<EOF
-20171030T153252
-EOF
-
-  run run_kill_old_containers
-
-  [ "${status}" -eq 0 ]
-  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=killed count=9"
 }
 
 @test "is a no-op if there are no containers" {
@@ -49,7 +26,7 @@ EOF
   run run_kill_old_containers
 
   [ "${status}" -eq 0 ]
-  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=noop count=0"
+  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=noop killed_count=0 not_killed_count=0"
 }
 
 @test "is a no-op if only travis-worker container is running" {
@@ -65,5 +42,5 @@ EOF
 
   [ "${status}" -eq 0 ]
 
-  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=killed count=0"
+  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=killed killed_count=0 not_killed_count=1"
 }

--- a/modules/aws_asg/kill-old-containers.bats
+++ b/modules/aws_asg/kill-old-containers.bats
@@ -25,7 +25,7 @@ EOF
   run run_kill_old_containers
 
   [ "${status}" -eq 0 ]
-  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=noop killed_count=0 not_killed_count=0"
+  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=warning killed_count=0 not_killed_count=0"
 }
 
 @test "is a no-op if only travis-worker container is running" {
@@ -41,5 +41,5 @@ EOF
 
   [ "${status}" -eq 0 ]
 
-  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=killed killed_count=0 not_killed_count=1"
+  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=noop killed_count=0 not_killed_count=1"
 }

--- a/modules/aws_asg/kill-old-containers.bats
+++ b/modules/aws_asg/kill-old-containers.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load bats_helpers
+
+setup() {
+  export MAX_AGE=120
+  aws_asg_setup
+}
+
+teardown() {
+  aws_asg_teardown
+}
+
+run_kill_old_containers() {
+  bash "${BATS_TEST_DIRNAME}/kill-old-containers.bash"
+}
+
+@test "removes containers older than travis-worker" {
+  cat >"${BATS_TMPDIR}/returns/docker" <<EOF
+4b4b1e76884b
+e2f6756f92d7
+75e342138b9e
+f2dc4be5a304
+9153fe19ef63
+32b7af38a72a
+098460f0b007
+76ca3e25d62a
+83a9c5a0eb61
+EOF
+
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+
+  run run_kill_old_containers
+  cat "${BATS_TMPDIR}/logs/mock.log" > /tmp/log
+
+  [ "${status}" -eq 0 ]
+  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=killed count=9"
+}
+
+@test "is a no-op if there are no old containers" {
+  cat >"${BATS_TMPDIR}/returns/docker" <<EOF
+EOF
+
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+
+  run run_kill_old_containers
+  cat "${BATS_TMPDIR}/logs/mock.log" >> /tmp/log
+
+  [ "${status}" -eq 0 ]
+  assert_cmd "logger time=20171030T153252  prog=kill-old-containers.bash status=noop count=0"
+}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

For some reason, some containers continue running well beyond the maximum time limit for jobs.

## What approach did you choose and why?

This PR adds a cron job to check for, and remove, any containers that are older than three hours (10800 seconds).

## How can you test this?

I don't know how to reproduce the issue of containers living beyond their expected time. But one could apply in staging and monitor the logs for killed containers.

## What feedback would you like, if any?

Is it safe to assume that containers killed in this way will not get requeued?