### PR TITLE
Separate jupiter-brain, worker env to a dedicated `wjb-staging` host

### DIFF
--- a/macstadium-pod-1/main.tf
+++ b/macstadium-pod-1/main.tf
@@ -139,8 +139,8 @@ module "jupiter_brain_production_org" {
 
 module "jupiter_brain_staging_org" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-org-env"
@@ -163,8 +163,8 @@ module "jupiter_brain_production_com" {
 
 module "jupiter_brain_staging_com" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-com-env"
@@ -257,8 +257,8 @@ module "worker_production_org_2" {
 
 module "worker_staging_org_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-1"
@@ -268,8 +268,8 @@ module "worker_staging_org_1" {
 
 module "worker_staging_org_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-2"
@@ -301,8 +301,8 @@ module "worker_production_com_2" {
 
 module "worker_staging_com_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-1"
@@ -312,8 +312,8 @@ module "worker_staging_com_1" {
 
 module "worker_staging_com_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-2"

--- a/macstadium-pod-1/main.tf
+++ b/macstadium-pod-1/main.tf
@@ -139,8 +139,8 @@ module "jupiter_brain_production_org" {
 
 module "jupiter_brain_staging_org" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-org-env"
@@ -163,8 +163,8 @@ module "jupiter_brain_production_com" {
 
 module "jupiter_brain_staging_com" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-com-env"
@@ -257,8 +257,8 @@ module "worker_production_org_2" {
 
 module "worker_staging_org_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-1"
@@ -268,8 +268,8 @@ module "worker_staging_org_1" {
 
 module "worker_staging_org_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-2"
@@ -301,8 +301,8 @@ module "worker_production_com_2" {
 
 module "worker_staging_com_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-1"
@@ -312,8 +312,8 @@ module "worker_staging_com_1" {
 
 module "worker_staging_com_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-2"
@@ -389,8 +389,8 @@ module "vsphere_janitor_production_com" {
 
 module "vsphere_janitor_staging_com" {
   source      = "../modules/vsphere_janitor"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.vsphere_janitor_staging_version}"
   config_path = "${path.module}/config/vsphere-janitor-staging-com"

--- a/macstadium-pod-2/main.tf
+++ b/macstadium-pod-2/main.tf
@@ -135,8 +135,8 @@ module "jupiter_brain_production_org" {
 
 module "jupiter_brain_staging_org" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-org-env"
@@ -159,8 +159,8 @@ module "jupiter_brain_production_com" {
 
 module "jupiter_brain_staging_com" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-com-env"
@@ -241,8 +241,8 @@ module "worker_production_org_2" {
 
 module "worker_staging_org_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-1"
@@ -252,8 +252,8 @@ module "worker_staging_org_1" {
 
 module "worker_staging_org_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-2"
@@ -263,8 +263,8 @@ module "worker_staging_org_2" {
 
 module "worker_staging_com_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-1"
@@ -274,8 +274,8 @@ module "worker_staging_com_1" {
 
 module "worker_com_staging_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-2"
@@ -362,8 +362,8 @@ module "vsphere_janitor_production_com" {
 
 module "vsphere_janitor_staging_com" {
   source      = "../modules/vsphere_janitor"
-  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb_staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb_staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.vsphere_janitor_staging_version}"
   config_path = "${path.module}/config/vsphere-janitor-staging-com"

--- a/macstadium-pod-2/main.tf
+++ b/macstadium-pod-2/main.tf
@@ -135,8 +135,8 @@ module "jupiter_brain_production_org" {
 
 module "jupiter_brain_staging_org" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-org-env"
@@ -159,8 +159,8 @@ module "jupiter_brain_production_com" {
 
 module "jupiter_brain_staging_com" {
   source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id        = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user       = "${var.ssh_user}"
   version        = "${var.jupiter_brain_staging_version}"
   config_path    = "${path.module}/config/jupiter-brain-staging-com-env"
@@ -241,8 +241,8 @@ module "worker_production_org_2" {
 
 module "worker_staging_org_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-1"
@@ -252,8 +252,8 @@ module "worker_staging_org_1" {
 
 module "worker_staging_org_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-org-2"
@@ -263,8 +263,8 @@ module "worker_staging_org_2" {
 
 module "worker_staging_com_1" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-1"
@@ -274,8 +274,8 @@ module "worker_staging_com_1" {
 
 module "worker_com_staging_2" {
   source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.latest_travis_worker_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-2"
@@ -362,8 +362,8 @@ module "vsphere_janitor_production_com" {
 
 module "vsphere_janitor_staging_com" {
   source      = "../modules/vsphere_janitor"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
+  host_id     = "${module.macstadium_infrastructure.wjb-staging_uuid}"
+  ssh_host    = "${module.macstadium_infrastructure.wjb-staging_ip}"
   ssh_user    = "${var.ssh_user}"
   version     = "${var.vsphere_janitor_staging_version}"
   config_path = "${path.module}/config/vsphere-janitor-staging-com"

--- a/modules/macstadium_infrastructure/dns.tf
+++ b/modules/macstadium_infrastructure/dns.tf
@@ -14,6 +14,15 @@ resource "aws_route53_record" "wjb" {
   records = ["${vsphere_virtual_machine.wjb.network_interface.0.ipv4_address}"]
 }
 
+resource "aws_route53_record" "wjb_staging" {
+  zone_id = "${var.travisci_net_external_zone_id}"
+  name    = "wjb-staging-${var.index}.macstadium-us-se-1.travisci.net"
+  type    = "A"
+  ttl     = 300
+  records = ["${vsphere_virtual_machine.wjb_staging.network_interface.0.ipv4_address}"]
+}
+
+
 resource "aws_route53_record" "util" {
   zone_id = "${var.travisci_net_external_zone_id}"
   name    = "util-${var.index}.macstadium-us-se-1.travisci.net"

--- a/modules/macstadium_infrastructure/wjb.tf
+++ b/modules/macstadium_infrastructure/wjb.tf
@@ -22,7 +22,7 @@ resource "vsphere_virtual_machine" "wjb" {
 
   network_interface {
     label              = "${var.management_network_label}"
-    ipv4_address       = "${cidrhost("10.88.208.0/23", 496 + var.index)}"
+    ipv4_address       = "${cidrhost("10.88.242.0/23", 496 + var.index)}"
     ipv4_prefix_length = "23"
   }
 

--- a/modules/macstadium_infrastructure/wjb_staging.tf
+++ b/modules/macstadium_infrastructure/wjb_staging.tf
@@ -1,5 +1,5 @@
-resource "vsphere_virtual_machine" "wjb-staging" {
-  name       = "wjb-staging-${var.index}"
+resource "vsphere_virtual_machine" "wjb_staging" {
+  name       = "wjb_staging-${var.index}"
   folder     = "${vsphere_folder.internal_vms.path}"
   vcpu       = 4
   memory     = 4096
@@ -32,7 +32,7 @@ resource "vsphere_virtual_machine" "wjb-staging" {
   }
 
   connection {
-    host  = "${vsphere_virtual_machine.wjb-staging.network_interface.0.ipv4_address}"
+    host  = "${vsphere_virtual_machine.wjb_staging.network_interface.0.ipv4_address}"
     user  = "${var.ssh_user}"
     agent = true
   }
@@ -46,12 +46,12 @@ resource "vsphere_virtual_machine" "wjb-staging" {
 
 resource "null_resource" "worker" {
   triggers {
-    host_id                = "${vsphere_virtual_machine.wjb-staging.uuid}"
+    host_id                = "${vsphere_virtual_machine.wjb_staging.uuid}"
     ssh_key_file_signature = "${sha256(file(var.vm_ssh_key_path))}"
   }
 
   connection {
-    host  = "${vsphere_virtual_machine.wjb-staging.network_interface.0.ipv4_address}"
+    host  = "${vsphere_virtual_machine.wjb_staging.network_interface.0.ipv4_address}"
     user  = "${var.ssh_user}"
     agent = true
   }
@@ -71,10 +71,10 @@ resource "null_resource" "worker" {
   }
 }
 
-output "wjb-staging_ip" {
-  value = "${vsphere_virtual_machine.wjb-staging.network_interface.0.ipv4_address}"
+output "wjb_staging_ip" {
+  value = "${vsphere_virtual_machine.wjb_staging.network_interface.0.ipv4_address}"
 }
 
-output "wjb-staging_uuid" {
-  value = "${vsphere_virtual_machine.wjb-staging.uuid}"
+output "wjb_staging_uuid" {
+  value = "${vsphere_virtual_machine.wjb_staging.uuid}"
 }

--- a/modules/macstadium_infrastructure/wjb_staging.tf
+++ b/modules/macstadium_infrastructure/wjb_staging.tf
@@ -44,7 +44,7 @@ resource "vsphere_virtual_machine" "wjb_staging" {
   }
 }
 
-resource "null_resource" "worker" {
+resource "null_resource" "worker-staging" {
   triggers {
     host_id                = "${vsphere_virtual_machine.wjb_staging.uuid}"
     ssh_key_file_signature = "${sha256(file(var.vm_ssh_key_path))}"

--- a/modules/macstadium_infrastructure/wjb_staging.tf
+++ b/modules/macstadium_infrastructure/wjb_staging.tf
@@ -1,0 +1,80 @@
+resource "vsphere_virtual_machine" "wjb-staging" {
+  name       = "wjb-staging-${var.index}"
+  folder     = "${vsphere_folder.internal_vms.path}"
+  vcpu       = 4
+  memory     = 4096
+  datacenter = "${var.datacenter}"
+  cluster    = "${var.cluster}"
+  domain     = "macstadium-us-se-1.travisci.net"
+
+  network_interface {
+    label              = "${var.internal_network_label}"
+    ipv4_address       = "${cidrhost("10.182.64.0/18", 30 + var.index)}"
+    ipv4_gateway       = "10.182.64.1"
+    ipv4_prefix_length = "18"
+  }
+
+  network_interface {
+    label              = "${var.jobs_network_label}"
+    ipv4_address       = "${cidrhost(var.jobs_network_subnet, 30 + var.index)}"
+    ipv4_prefix_length = "18"
+  }
+
+  network_interface {
+    label              = "${var.management_network_label}"
+    ipv4_address       = "${cidrhost("10.88.208.0/23", 496 + var.index)}"
+    ipv4_prefix_length = "23"
+  }
+
+  disk {
+    template  = "${vsphere_folder.vanilla_vms.path}/${var.vanilla_image}"
+    datastore = "${var.datastore}"
+  }
+
+  connection {
+    host  = "${vsphere_virtual_machine.wjb-staging.network_interface.0.ipv4_address}"
+    user  = "${var.ssh_user}"
+    agent = true
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "curl -s -v 'https://app.threatstack.com/agents/script?key=${var.threatstack_key}' | sudo bash",
+    ]
+  }
+}
+
+resource "null_resource" "worker" {
+  triggers {
+    host_id                = "${vsphere_virtual_machine.wjb-staging.uuid}"
+    ssh_key_file_signature = "${sha256(file(var.vm_ssh_key_path))}"
+  }
+
+  connection {
+    host  = "${vsphere_virtual_machine.wjb-staging.network_interface.0.ipv4_address}"
+    user  = "${var.ssh_user}"
+    agent = true
+  }
+
+  provisioner "file" {
+    source      = "${var.vm_ssh_key_path}"
+    destination = "/tmp/travis-vm-ssh-key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "if ! getent passwd travis-worker >/dev/null; then sudo useradd -r -s /usr/bin/nologin travis-worker; fi",
+      "sudo mv /tmp/travis-vm-ssh-key /etc/travis-vm-ssh-key",
+      "sudo chown travis-worker:travis-worker /etc/travis-vm-ssh-key",
+      "sudo chmod 0600 /etc/travis-vm-ssh-key",
+    ]
+  }
+}
+
+output "wjb-staging_ip" {
+  value = "${vsphere_virtual_machine.wjb-staging.network_interface.0.ipv4_address}"
+}
+
+output "wjb-staging_uuid" {
+  value = "${vsphere_virtual_machine.wjb-staging.uuid}"
+}

--- a/modules/macstadium_infrastructure/wjb_staging.tf
+++ b/modules/macstadium_infrastructure/wjb_staging.tf
@@ -22,7 +22,7 @@ resource "vsphere_virtual_machine" "wjb-staging" {
 
   network_interface {
     label              = "${var.management_network_label}"
-    ipv4_address       = "${cidrhost("10.88.208.0/23", 496 + var.index)}"
+    ipv4_address       = "${cidrhost("10.88.242.0/23", 496 + var.index)}"
     ipv4_prefix_length = "23"
   }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Currently all the jupiter-brain, worker, and vsphere-janitor instances sit on the same linux host as the production instances.   This PR aims to separate all staging services to a new host for isolated testing. 
## What approach did you choose and why?


## How can you test this?
See what the output of a `make plan` looks like. 

## What feedback would you like, if any?
I would like to the same modules but parsed to different hosts if possible. The latest commit sent me down a path I don't wan't to go down: making a whole new `wjb-staging` module that reuses much of the `wjb.tf` it is copied from, and I'd like to use the wjb.tf to make 2 separate hosts with their respective {env}-{instance}
