### PR TITLE
Do not do double work

### DIFF
--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -44,8 +44,6 @@ INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
 .PHONY: .config
 .config: $(CONFIG_FILES) $(ENV_NAME).tfvars
-
-$(CONFIG_FILES):
 	mkdir -p config
 	cp -v $$TRAVIS_KEYCHAIN_DIR/travis-keychain/macstadium/travis-vm-ssh-key config/
 	trvs generate-config -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX) \

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -41,8 +41,6 @@ INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
 .PHONY: .config
 .config: $(CONFIG_FILES) $(ENV_NAME).tfvars
-
-$(CONFIG_FILES):
 	mkdir -p config
 	cp -v $$TRAVIS_KEYCHAIN_DIR/travis-keychain/macstadium/travis-vm-ssh-key config/
 	trvs generate-config -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX) \

--- a/macstadium-shared-1/Makefile
+++ b/macstadium-shared-1/Makefile
@@ -47,8 +47,6 @@ INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
 .PHONY: .config
 .config: $(CONFIG_FILES) $(ENV_NAME).tfvars
-
-$(CONFIG_FILES):
 	mkdir -p config
 	cp -v $$TRAVIS_KEYCHAIN_DIR/travis-keychain/macstadium/travis-vm-ssh-key config/
 	trvs generate-config -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX) \

--- a/macstadium-shared-2/Makefile
+++ b/macstadium-shared-2/Makefile
@@ -44,8 +44,6 @@ INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
 .PHONY: .config
 .config: $(CONFIG_FILES) $(ENV_NAME).tfvars
-
-$(CONFIG_FILES):
 	mkdir -p config
 	cp -v $$TRAVIS_KEYCHAIN_DIR/travis-keychain/macstadium/travis-vm-ssh-key config/
 	trvs generate-config -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX) \


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The recipe for the `$(CONFIG_FILES)` expands into a lot of targets. The recipe has been running for each of these targets on each invocation of `make plan`. This change runs the recipe once.

## What approach did you choose and why?
Ensure there is a single target for recipe that needs to be executed once.

## How can you test this?
Count how often lines from the recipes get into the output. `mkdir -p config`, for example.

## What feedback would you like, if any?
