### PR TITLE
GCE worker updates

### DIFF
--- a/assets/travis-worker/travis-worker@.service
+++ b/assets/travis-worker/travis-worker@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Travis Worker
+After=docker.service
+Requires=docker.service
+
+[Service]
+ExecStart=/usr/local/bin/travis-worker-wrapper travis-worker-%I
+ExecStopPost=/bin/sleep 5
+Restart=always
+WorkingDirectory=/
+User=travis
+
+[Install]
+WantedBy=multi-user.target

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -3,14 +3,14 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1478778272"
+  default = "eco-emissary-99515/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1499625597"
+  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -63,8 +63,8 @@ module "gce_project_1" {
   worker_account_json_com       = "${file("${path.module}/config/gce-workers-production-1.json")}"
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-1.json")}"
   worker_image                  = "${var.gce_worker_image}"
-  worker_instance_count_com     = 36
-  worker_instance_count_org     = 40
+  worker_instance_count_com     = 16
+  worker_instance_count_org     = 20
 
   build_com_subnet_cidr_range = "10.99.99.0/24"
   build_org_subnet_cidr_range = "10.10.20.0/22"

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -3,14 +3,14 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1478778272"
+  default = "eco-emissary-99515/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1499625597"
+  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -5,14 +5,14 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1478778272"
+  default = "eco-emissary-99515/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1499625597"
+  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -5,14 +5,14 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1478778272"
+  default = "eco-emissary-99515/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1499625597"
+  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -5,14 +5,14 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1478778272"
+  default = "eco-emissary-99515/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1499625597"
+  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -10,7 +10,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1499625597"
+  default = "eco-emissary-99515/tfw-1516641023-064b6d3"
 }
 
 variable "github_users" {}

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -10,7 +10,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516641023-064b6d3"
+  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -236,7 +236,7 @@ resource "google_compute_firewall" "deny_target_ip" {
   project = "${var.project}"
 
   # highest priority
-  priority = "0"
+  priority = "1000"
 
   deny {
     protocol = "tcp"

--- a/modules/gce_worker/cloud-config.yml.tpl
+++ b/modules/gce_worker/cloud-config.yml.tpl
@@ -42,10 +42,10 @@ write_files:
   encoding: b64
   owner: 'root:root'
   path: /var/tmp/travis-worker.conf
-- content: '${base64encode(file("${assets}/travis-worker/travis-worker.service"))}'
+- content: '${base64encode(file("${assets}/travis-worker/travis-worker@.service"))}'
   encoding: b64
   owner: 'root:root'
-  path: /var/tmp/travis-worker.service
+  path: /var/tmp/travis-worker@.service
 - content: '${base64encode(file("${assets}/travis-worker/rsyslog-watch-upstart.conf"))}'
   encoding: b64
   owner: 'root:root'

--- a/modules/gce_worker/cloud-init.bash
+++ b/modules/gce_worker/cloud-init.bash
@@ -13,10 +13,12 @@ main() {
   chown -R travis:travis "${RUNDIR}"
 
   if [[ -d "${ETCDIR}/systemd/system" ]]; then
+    cp -v "${VARTMP}/travis-worker@.service" \
+      "${ETCDIR}/systemd/system/travis-worker@.service"
+
     for worker_suffix in ${WORKER_SUFFIXES}; do
-      cp -v "${VARTMP}/travis-worker.service" \
-        "${ETCDIR}/systemd/system/travis-worker-${worker_suffix}.service"
-      systemctl enable "travis-worker-${worker_suffix}" || true
+      systemctl enable "travis-worker@${worker_suffix}" || true
+      systemctl start "travis-worker@${worker_suffix}" || true
     done
   fi
 
@@ -25,12 +27,12 @@ main() {
       cp -v "${VARTMP}/travis-worker.conf" \
         "${ETCDIR}/init/travis-worker-${worker_suffix}.conf"
     done
-  fi
 
-  for worker_suffix in ${WORKER_SUFFIXES}; do
-    service "travis-worker-${worker_suffix}" stop || true
-    service "travis-worker-${worker_suffix}" start || true
-  done
+    for worker_suffix in ${WORKER_SUFFIXES}; do
+      service "travis-worker-${worker_suffix}" stop || true
+      service "travis-worker-${worker_suffix}" start || true
+    done
+  fi
 
   __wait_for_docker
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current (unused) systemd service definition for `travis-worker-{a,b,c}` on GCE does not work, as the `travis-worker-wrapper` script is not given a variable positional argument from which a container name is derived.

## What approach did you choose and why?

Use a systemd instance-style service definition so that stuff works right.  Also use the latest xenial tfw image.

## How can you test this?

- [x] delete a staging GCE worker host
- [x] `make plan`, `make apply`
- [x] cycle remaining hosts in gce-staging-1
- [x] cycle hosts in gce-production-1
- [x] cycle hosts in gce-production-2
- [x] cycle hosts in gce-production-3
- [x] cycle hosts in gce-production-4
- [x] cycle hosts in gce-production-5