### PR TITLE
Change 'debug' from 'true' to 'false' in docker_daemon_json.

### DIFF
--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -177,7 +177,7 @@ data "template_file" "docker_daemon_json" {
     "dm.fs=xfs"
   ],
   "userns-remap": "default",
-  "debug": true
+  "debug": false
 }
 EOF
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Docker debug mode was turned on in https://github.com/travis-ci/terraform-config/pull/277. It's rather noisy and we're not actively investigating this right now, so might as well turn it off.

## What approach did you choose and why?

Replace `"debug": true` with `"debug": false` in the template that will become `/etc/docker/daemon-direct-lvm.json`.