### PR TITLE
GCE NAT rework

### DIFF
--- a/assets/nat/travis-nat-health-check
+++ b/assets/nat/travis-nat-health-check
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# This is a modified version of the health check code available via:
+# $ gsutil cp gs://nat-gw-template/startup.sh .
+import os
+import subprocess
+import sys
+
+from wsgiref.util import setup_testing_defaults
+from wsgiref.simple_server import make_server
+
+
+PORT_NUMBER = 80
+PING_HOST = 'www.google.com'
+
+
+def check_connectivity(ping_host):
+    try:
+        subprocess.check_call(['ping', '-c', '1', ping_host])
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def health_app(environ, start_response):
+    setup_testing_defaults(environ)
+    ping_host = os.environ.get('PING_HOST', PING_HOST)
+
+    def resp(status, body):
+        body = body.encode('utf-8')
+        start_response(status, [
+            ('content-type', 'text/plain; charset=utf-8'),
+            ('content-length', str(len(body))),
+        ])
+        return [body]
+
+    if environ['PATH_INFO'] == '/health-check':
+        if check_connectivity(ping_host):
+            return resp('200 OK', 'ok\n')
+        else:
+            return resp('503 Internal Server Error', 'oh no\n')
+
+    return resp('404 Not Found', 'what\n')
+
+
+def main():
+    port_number = int(os.environ.get('PORT', PORT_NUMBER))
+    httpd = make_server('', port_number, health_app)
+    print('Serving health check app on port {}...'.format(port_number))
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/assets/nat/travis-nat-health-check.service
+++ b/assets/nat/travis-nat-health-check.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Travis NAT Health Check
+
+[Service]
+ExecStart=/usr/local/bin/travis-nat-health-check
+Restart=always
+WorkingDirectory=/
+
+[Install]
+WantedBy=multi-user.target

--- a/bin/gcloud-nats-by-zone
+++ b/bin/gcloud-nats-by-zone
@@ -1,101 +1,72 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env ruby
 
-import datetime
-import json
-import os
-import subprocess
-import sys
-import textwrap
-import time
+require 'json'
 
+NOTSET = '<notset>'
 
-def main(sysargs=sys.argv[:]):
-    prog = sysargs[0]
-    _log = make_log(prog)
-    if sys.stdin.isatty() or '-h' in sysargs[1:] or '--help' in sysargs[1:]:
-        return _usage(prog)
+def main(argv: ARGV)
+  if $stdin.tty? || argv.include?('-h') || argv.include?('--help')
+    return usage
+  end
 
-    in_args = json.load(sys.stdin)
-    zones = list(filter(lambda s: s != '', [
-        z.strip() for z in in_args.get('zones', '').split(',')
-    ]))
-    project = in_args['project']
-    region = in_args['region']
-    retries = int(in_args.get('retries', '4'))
-    retry_sleep = int(in_args.get('retry_sleep', '120'))
-    retried = 0
+  in_args = JSON.parse($stdin.read)
+  zones = in_args.fetch('zones', '').split(',').map(&:strip).reject(&:empty?)
+  project = in_args.fetch('project')
+  region = in_args.fetch('region')
+  retries = Integer(in_args.fetch('retries', '4'))
+  retry_sleep = Integer(in_args.fetch('retry_sleep', '120'))
+  retried = 0
 
-    instances = {}
-    while retried <= retries:
-        instances = _fetch_nats_by_zone(zones, project, region, _log)
-        if instances['__count__'] == str(len(zones)):
-            break
-        _log('instances={!r} sleeping={}s'.format(instances, retry_sleep))
-        time.sleep(retry_sleep)
-        retried += 1
+  instances = {}
+  while retried <= retries
+    instances = fetch_nats_by_zone(zones, project, region)
+    break if instances.length == zones.length
 
-    print(json.dumps(instances, sort_keys=True, indent=4))
-    return 0
+    $stderr.puts("#{$PROGRAM_NAME}: sleeping=#{retry_sleep}s")
+    sleep(retry_sleep)
+    retried += 1
+  end
 
+  $stdout.puts(JSON.pretty_generate(instances))
+  0
+end
 
-def _fetch_nats_by_zone(zones, project, region, _log):
-    instances = {'__count__': '0'}
-    instances_command = [
-        'gcloud', 'compute', 'instance-groups', 'list-instances',
-    ]
+def fetch_nats_by_zone(zones, project, region)
+  instances = {}
+  instances_command = %w[
+    gcloud compute instance-groups list-instances
+  ]
 
-    for zone in zones:
-        try:
-            instance_name = subprocess.check_output(
-                instances_command + [
-                    'nat-{}'.format(zone),
-                    '--project={}'.format(project),
-                    '--zone={}-{}'.format(region, zone),
-                    '--format=value(instance)',
-                ]
-            ).strip()
-            _log('zone={} instance_name={}'.format(zone, instance_name))
-            instances[zone] = instance_name.decode('utf-8')
-        except subprocess.CalledProcessError:
-            instances[zone] = '<notset>'
+  zones.each do |zone|
+    begin
+      full_command = instances_command + %W[
+        nat-#{zone}
+        --project=#{project}
+        --zone=#{region}-#{zone}
+        --format="value(instance)"
+      ]
+      instance_name = `#{full_command.join(' ')}`.strip
+      instances[zone] = instance_name
+    rescue => e
+      warn e
+    end
+  end
 
-    if '<notset>' not in instances.values():
-        instances['__count__'] = str(len(instances) - 1)
+  instances
+end
 
-    return instances
+def usage
+  $stderr.puts <<~EOF
+    Usage: #{$PROGRAM_NAME} [-h|--help]
 
+    Print a mapping of zone=>instance-id given a JSON blob containing
+    the following arguments provided via stdin:
 
-def _usage(prog):
-    print(textwrap.dedent("""\
-        Usage: {prog} [-h|--help]
+    project - the gcloud project name
+    region - the region in which to look for nat instances
+    zones - a comma-delimited list of zones within the region
+  EOF
+  2
+end
 
-        Print a mapping of zone=>instance-id given a JSON blob containing
-        the following arguments provided via stdin:
-
-        project - the gcloud project name
-        region - the region in which to look for nat instances
-        zones - a comma-delimited list of zones within the region
-    """).format(prog=prog), file=sys.stderr)
-    return 2
-
-
-def make_log(prog):
-    out = sys.stderr
-    if os.environ.get('DEBUG_LOG') is not None:
-        out = open(os.environ['DEBUG_LOG'], 'a+')
-
-    def _log(msg):
-        print(
-            '{prog}:{now} {msg}'.format(
-                  prog=prog, now=datetime.datetime.now().isoformat(), msg=msg
-            ),
-            file=out
-        )
-        out.flush()
-
-    return _log
-
-
-if __name__ == '__main__':
-    sys.exit(main())
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/bin/gcloud-nats-by-zone
+++ b/bin/gcloud-nats-by-zone
@@ -1,16 +1,20 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+import datetime
 import json
 import os
 import subprocess
 import sys
 import textwrap
+import time
 
 
 def main(sysargs=sys.argv[:]):
+    prog = sysargs[0]
+    _log = make_log(prog)
     if sys.stdin.isatty() or '-h' in sysargs[1:] or '--help' in sysargs[1:]:
-        return _usage()
+        return _usage(prog)
 
     in_args = json.load(sys.stdin)
     zones = list(filter(lambda s: s != '', [
@@ -18,10 +22,27 @@ def main(sysargs=sys.argv[:]):
     ]))
     project = in_args['project']
     region = in_args['region']
+    retries = int(in_args.get('retries', '4'))
+    retry_sleep = int(in_args.get('retry_sleep', '120'))
+    retried = 0
 
+    instances = {}
+    while retried <= retries:
+        instances = _fetch_nats_by_zone(zones, project, region, _log)
+        if instances['__count__'] == str(len(zones)):
+            break
+        _log('instances={!r} sleeping={}s'.format(instances, retry_sleep))
+        time.sleep(retry_sleep)
+        retried += 1
+
+    print(json.dumps(instances, sort_keys=True, indent=4))
+    return 0
+
+
+def _fetch_nats_by_zone(zones, project, region, _log):
     instances = {'__count__': '0'}
     instances_command = [
-        'gcloud', 'compute', 'instance-groups', 'managed', 'list-instances',
+        'gcloud', 'compute', 'instance-groups', 'list-instances',
     ]
 
     for zone in zones:
@@ -34,17 +55,18 @@ def main(sysargs=sys.argv[:]):
                     '--format=value(instance)',
                 ]
             ).strip()
+            _log('zone={} instance_name={}'.format(zone, instance_name))
             instances[zone] = instance_name.decode('utf-8')
         except subprocess.CalledProcessError:
             instances[zone] = '<notset>'
 
     if '<notset>' not in instances.values():
         instances['__count__'] = str(len(instances) - 1)
-    print(json.dumps(instances, sort_keys=True, indent=4))
-    return 0
+
+    return instances
 
 
-def _usage(sysargs=sys.argv[:]):
+def _usage(prog):
     print(textwrap.dedent("""\
         Usage: {prog} [-h|--help]
 
@@ -54,8 +76,26 @@ def _usage(sysargs=sys.argv[:]):
         project - the gcloud project name
         region - the region in which to look for nat instances
         zones - a comma-delimited list of zones within the region
-    """).format(prog=sysargs[0]))
+    """).format(prog=prog), file=sys.stderr)
     return 2
+
+
+def make_log(prog):
+    out = sys.stderr
+    if os.environ.get('DEBUG_LOG') is not None:
+        out = open(os.environ['DEBUG_LOG'], 'a+')
+
+    def _log(msg):
+        print(
+            '{prog}:{now} {msg}'.format(
+                  prog=prog, now=datetime.datetime.now().isoformat(), msg=msg
+            ),
+            file=out
+        )
+        out.flush()
+
+    return _log
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/bin/gcloud-nats-by-zone
+++ b/bin/gcloud-nats-by-zone
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def main(sysargs=sys.argv[:]):
+    if sys.stdin.isatty() or '-h' in sysargs[1:] or '--help' in sysargs[1:]:
+        return _usage()
+
+    in_args = json.load(sys.stdin)
+    zones = list(filter(lambda s: s != '', [
+        z.strip() for z in in_args.get('zones', '').split(',')
+    ]))
+    project = in_args['project']
+    region = in_args['region']
+
+    instances = {'__count__': '0'}
+    instances_command = [
+        'gcloud', 'compute', 'instance-groups', 'managed', 'list-instances',
+    ]
+
+    for zone in zones:
+        try:
+            instance_name = subprocess.check_output(
+                instances_command + [
+                    'nat-{}'.format(zone),
+                    '--project={}'.format(project),
+                    '--zone={}-{}'.format(region, zone),
+                    '--format=value(instance)',
+                ]
+            ).strip()
+            instances[zone] = instance_name.decode('utf-8')
+        except subprocess.CalledProcessError:
+            instances[zone] = '<notset>'
+
+    if '<notset>' not in instances.values():
+        instances['__count__'] = str(len(instances) - 1)
+    print(json.dumps(instances, sort_keys=True, indent=4))
+    return 0
+
+
+def _usage(sysargs=sys.argv[:]):
+    print(textwrap.dedent("""\
+        Usage: {prog} [-h|--help]
+
+        Print a mapping of zone=>instance-id given a JSON blob containing
+        the following arguments provided via stdin:
+
+        project - the gcloud project name
+        region - the region in which to look for nat instances
+        zones - a comma-delimited list of zones within the region
+    """).format(prog=sysargs[0]))
+    return 2
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bin/generate-latest-gce-images
+++ b/bin/generate-latest-gce-images
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+DEFAULT_GCE_PROJECT_ID = 'eco-emissary-99515'
+DEFAULT_IMAGE_PREFIXES = 'bastion nat tfw'
+
+def main(argv: ARGV)
+  if argv.include?('-h') || argv.include?('--help')
+    return usage
+  end
+
+  project = ENV['GCE_PROJECT_ID'] || DEFAULT_GCE_PROJECT_ID
+  prefixes = (
+    ENV['IMAGE_PREFIXES'] || DEFAULT_IMAGE_PREFIXES
+  ).split.map(&:strip)
+
+  prefixes.each do |prefix|
+    name = fetch_latest_image_name(prefix, project)
+    $stdout.puts %[latest_gce_#{prefix}_image = "#{project}/#{name}"]
+  end
+
+  0
+end
+
+def fetch_latest_image_name(prefix, project)
+  command = %W[
+    gcloud compute images list
+    --project=#{project}
+    --filter='name~^#{prefix}-'
+    --format='value(name)'
+  ].join(' ')
+  names = `#{command}`.split.map(&:strip)
+  names.sort.last
+end
+
+def usage
+  $stderr.puts <<~EOF
+    Usage: #{$PROGRAM_NAME} [-h|--help]
+
+    Generate a list of (some of) the latest known GCE images as tfvars.
+  EOF
+  2
+end
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/bin/generate-tfvars
+++ b/bin/generate-tfvars
@@ -23,6 +23,11 @@ main() {
     __cleanup "${out}"
     exit 1
   fi
+
+  if ! "${top}/bin/generate-latest-gce-images"; then
+    __cleanup "${out}"
+    exit 1
+  fi
 }
 
 __cleanup() {

--- a/bin/write-config-files
+++ b/bin/write-config-files
@@ -35,6 +35,16 @@ def main(argv: ARGV)
     )
   end
 
+  if opts[:write_nat]
+    fwrite(
+      'config/nat.env',
+      trvs_gen(
+        "#{opts[:infra]}-nat", opts[:env_short],
+        pro: true, prefix: "#{opts[:infra].upcase}_NAT"
+      )
+    )
+  end
+
   {
     'config/travis-org.env' => "travis-#{opts[:env_short]}",
     'config/travis-build-org.env' => "travis-build-#{opts[:env_short]}",
@@ -103,7 +113,8 @@ def parse_argv(argv)
     build_org_host: '',
     job_board_host: '',
     amqp_url_varname: '',
-    write_bastion: false
+    write_bastion: false,
+    write_nat: false
   }
 
   OptionParser.new do |o|
@@ -137,6 +148,10 @@ def parse_argv(argv)
 
     o.on('--write-bastion') do
       opts[:write_bastion] = true
+    end
+
+    o.on('--write-nat') do
+      opts[:write_nat] = true
     end
   end.parse(argv)
 

--- a/gce-staging-1/Makefile
+++ b/gce-staging-1/Makefile
@@ -4,3 +4,6 @@ JOB_BOARD_HOST := job-board-staging.travis-ci.com
 AMQP_URL_VARNAME := RABBITMQ_BIGWIG_RX_URL
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
+
+PROD_TF_VERSION := v0.11.2
+TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -2,17 +2,9 @@ variable "env" {
   default = "staging"
 }
 
-variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
-}
-
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
-
-variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
-}
-
+variable "latest_gce_tfw_image" {}
 variable "github_users" {}
 
 variable "index" {
@@ -83,7 +75,7 @@ module "gce_worker_group" {
   worker_account_json_com       = "${file("${path.module}/config/gce-workers-staging-1.json")}"
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-staging-1.json")}"
   worker_docker_self_image      = "${var.latest_docker_image_worker}"
-  worker_image                  = "${var.gce_worker_image}"
+  worker_image                  = "${var.latest_gce_tfw_image}"
   worker_subnetwork             = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_zones = "${var.worker_zones}"

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -76,6 +76,7 @@ module "gce_worker_group" {
   heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
   project                       = "travis-staging-1"
+  region                        = "us-central1"
   syslog_address_com            = "${var.syslog_address_com}"
   syslog_address_org            = "${var.syslog_address_org}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"

--- a/gce-staging-net-1/Makefile
+++ b/gce-staging-net-1/Makefile
@@ -1,0 +1,10 @@
+AMQP_URL_VARNAME := RABBITMQ_BIGWIG_RX_URL
+ENV_SHORT := staging
+JOB_BOARD_HOST := job-board-staging.travis-ci.com
+TRAVIS_BUILD_COM_HOST := build-staging.travis-ci.com
+TRAVIS_BUILD_ORG_HOST := build-staging.travis-ci.org
+
+include $(shell git rev-parse --show-toplevel)/gce.mk
+
+PROD_TF_VERSION := v0.11.2
+TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -7,10 +7,9 @@ variable "gce_bastion_image" {
 }
 
 variable "gce_nat_image" {
-  default = "eco-emissary-99515/nat-1481594315"
+  default = "eco-emissary-99515/nat-1517861556-35889bb"
 }
 
-variable "gce_gcloud_zone" {}
 variable "github_users" {}
 
 variable "index" {
@@ -51,7 +50,6 @@ module "gce_nat_1" {
   bastion_image                 = "${var.gce_bastion_image}"
   deny_target_ip_ranges         = ["${split(",", var.deny_target_ip_ranges)}"]
   env                           = "${var.env}"
-  gcloud_zone                   = "${var.gce_gcloud_zone}"
   github_users                  = "${var.github_users}"
   index                         = "${var.index}"
   nat_config                    = "${file("config/nat.env")}"

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -1,0 +1,63 @@
+variable "env" {
+  default = "staging"
+}
+
+variable "gce_bastion_image" {
+  default = "eco-emissary-99515/bastion-1496867305"
+}
+
+variable "gce_nat_image" {
+  default = "eco-emissary-99515/nat-1481594315"
+}
+
+variable "gce_gcloud_zone" {}
+variable "github_users" {}
+
+variable "index" {
+  default = 1
+}
+
+variable "travisci_net_external_zone_id" {
+  default = "Z2RI61YP4UWSIO"
+}
+
+variable "syslog_address_com" {}
+variable "syslog_address_org" {}
+
+variable "deny_target_ip_ranges" {}
+
+terraform {
+  backend "s3" {
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-stagingnet-1.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
+  }
+}
+
+provider "google" {
+  credentials = "${file("config/gce-workers-staging-1.json")}"
+  project     = "travis-staging-1"
+  region      = "us-central1"
+}
+
+provider "aws" {}
+
+module "gce_nat_1" {
+  source = "../modules/gce_net"
+
+  bastion_config                = "${file("config/bastion.env")}"
+  bastion_image                 = "${var.gce_bastion_image}"
+  deny_target_ip_ranges         = ["${split(",", var.deny_target_ip_ranges)}"]
+  env                           = "${var.env}"
+  gcloud_zone                   = "${var.gce_gcloud_zone}"
+  github_users                  = "${var.github_users}"
+  index                         = "${var.index}"
+  nat_config                    = "${file("config/nat.env")}"
+  nat_image                     = "${var.gce_nat_image}"
+  nat_machine_type              = "g1-small"
+  project                       = "travis-staging-1"
+  syslog_address                = "${var.syslog_address_com}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+}

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -2,13 +2,8 @@ variable "env" {
   default = "staging"
 }
 
-variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
-}
-
-variable "gce_nat_image" {
-  default = "eco-emissary-99515/nat-1517861556-35889bb"
-}
+variable "latest_gce_bastion_image" {}
+variable "latest_gce_nat_image" {}
 
 variable "github_users" {}
 
@@ -47,13 +42,13 @@ module "gce_net" {
   source = "../modules/gce_net"
 
   bastion_config                = "${file("config/bastion.env")}"
-  bastion_image                 = "${var.gce_bastion_image}"
+  bastion_image                 = "${var.latest_gce_bastion_image}"
   deny_target_ip_ranges         = ["${split(",", var.deny_target_ip_ranges)}"]
   env                           = "${var.env}"
   github_users                  = "${var.github_users}"
   index                         = "${var.index}"
   nat_config                    = "${file("config/nat.env")}"
-  nat_image                     = "${var.gce_nat_image}"
+  nat_image                     = "${var.latest_gce_nat_image}"
   nat_machine_type              = "g1-small"
   project                       = "travis-staging-1"
   syslog_address                = "${var.syslog_address_com}"

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -28,7 +28,7 @@ variable "deny_target_ip_ranges" {}
 terraform {
   backend "s3" {
     bucket         = "travis-terraform-state"
-    key            = "terraform-config/gce-stagingnet-1.tfstate"
+    key            = "terraform-config/gce-staging-net-1.tfstate"
     region         = "us-east-1"
     encrypt        = "true"
     dynamodb_table = "travis-terraform-state"
@@ -43,7 +43,7 @@ provider "google" {
 
 provider "aws" {}
 
-module "gce_nat_1" {
+module "gce_net" {
   source = "../modules/gce_net"
 
   bastion_config                = "${file("config/bastion.env")}"
@@ -58,4 +58,8 @@ module "gce_nat_1" {
   project                       = "travis-staging-1"
   syslog_address                = "${var.syslog_address_com}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+}
+
+output "gce_subnetwork_workers" {
+  value = "${module.gce_net.gce_subnetwork_workers}"
 }

--- a/gce.mk
+++ b/gce.mk
@@ -1,6 +1,6 @@
 include $(shell git rev-parse --show-toplevel)/terraform.mk
 
-WRITE_CONFIG_OPTS := --write-bastion --env-tail $(ENV_TAIL)
+WRITE_CONFIG_OPTS := --write-bastion --write-nat --env-tail $(ENV_TAIL)
 
 .PHONY: default
 default: hello

--- a/modules/gce_net/bastion-cloud-config.yml.tpl
+++ b/modules/gce_net/bastion-cloud-config.yml.tpl
@@ -1,0 +1,17 @@
+#cloud-config
+# vim:filetype=yaml
+
+write_files:
+- content: '${base64encode(github_users_env)}'
+  encoding: b64
+  path: /etc/default/github-users
+- content: '${base64encode(bastion_config)}'
+  encoding: b64
+  path: /etc/default/bastion
+- content: '${base64encode(cloud_init_bash)}'
+  encoding: b64
+  path: /var/lib/cloud/scripts/per-instance/99-bastion-cloud-init
+  permissions: '0750'
+- content: '${base64encode(syslog_address)}'
+  encoding: b64
+  path: /var/tmp/travis-run.d/syslog-address

--- a/modules/gce_net/bastion-cloud-init.bash
+++ b/modules/gce_net/bastion-cloud-init.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# vim:filetype=sh
+set -o errexit
+
+main() {
+  # shellcheck source=/dev/null
+  source /etc/default/bastion
+  __write_duo_configs \
+    "$GCE_BASTION_DUO_INTEGRATION_KEY" \
+    "$GCE_BASTION_DUO_SECRET_KEY" \
+    "$GCE_BASTION_DUO_API_HOSTNAME"
+}
+
+__write_duo_configs() {
+  for conf in /etc/duo/login_duo.conf /etc/duo/pam_duo.conf; do
+    cat >"$conf" <<EOF
+# Written by cloud-init $(date -u) :heart:
+[duo]
+ikey = $1
+skey = $2
+host = $3
+failmode = secure
+EOF
+  done
+}
+
+main "$@"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -1,0 +1,326 @@
+variable "bastion_config" {}
+variable "bastion_image" {}
+
+variable "deny_target_ip_ranges" {
+  type    = "list"
+  default = []
+}
+
+variable "env" {}
+variable "gcloud_zone" {}
+variable "github_users" {}
+variable "index" {}
+variable "nat_config" {}
+variable "nat_image" {}
+variable "nat_machine_type" {}
+variable "project" {}
+variable "syslog_address" {}
+variable "travisci_net_external_zone_id" {}
+
+variable "public_subnet_cidr_range" {
+  default = "10.10.0.0/22"
+}
+
+variable "workers_subnet_cidr_range" {
+  default = "10.10.4.0/22"
+}
+
+variable "jobs_org_subnet_cidr_range" {
+  default = "10.20.0.0/16"
+}
+
+variable "jobs_com_subnet_cidr_range" {
+  default = "10.30.0.0/16"
+}
+
+variable "build_com_subnet_cidr_range" {
+  default = "10.10.12.0/22"
+}
+
+variable "build_org_subnet_cidr_range" {
+  default = "10.10.8.0/22"
+}
+
+resource "google_compute_network" "main" {
+  name                    = "main"
+  project                 = "${var.project}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "public" {
+  name          = "public"
+  ip_cidr_range = "${var.public_subnet_cidr_range}"
+  network       = "${google_compute_network.main.self_link}"
+  region        = "us-central1"
+
+  project = "${var.project}"
+}
+
+resource "google_compute_subnetwork" "workers" {
+  name          = "workers"
+  ip_cidr_range = "${var.workers_subnet_cidr_range}"
+  network       = "${google_compute_network.main.self_link}"
+  region        = "us-central1"
+
+  project = "${var.project}"
+}
+
+resource "google_compute_subnetwork" "jobs_org" {
+  name          = "jobs-org"
+  ip_cidr_range = "${var.jobs_org_subnet_cidr_range}"
+  network       = "${google_compute_network.main.self_link}"
+  region        = "us-central1"
+
+  project = "${var.project}"
+}
+
+# TODO: remove this legacy subnetwork when no longer in use
+resource "google_compute_subnetwork" "build_org" {
+  name          = "buildorg"
+  ip_cidr_range = "${var.build_org_subnet_cidr_range}"
+  network       = "${google_compute_network.main.self_link}"
+  region        = "us-central1"
+
+  project = "${var.project}"
+}
+
+resource "google_compute_subnetwork" "jobs_com" {
+  name          = "jobs-com"
+  ip_cidr_range = "${var.jobs_com_subnet_cidr_range}"
+  network       = "${google_compute_network.main.self_link}"
+  region        = "us-central1"
+
+  project = "${var.project}"
+}
+
+# TODO: remove this legacy subnetwork when no longer in use
+resource "google_compute_subnetwork" "build_com" {
+  name          = "buildcom"
+  ip_cidr_range = "${var.build_com_subnet_cidr_range}"
+  network       = "${google_compute_network.main.self_link}"
+  region        = "us-central1"
+
+  project = "${var.project}"
+}
+
+resource "google_compute_firewall" "allow_public_ssh" {
+  name          = "allow-public-ssh"
+  network       = "${google_compute_network.main.name}"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["bastion"]
+
+  project = "${var.project}"
+
+  allow {
+    protocol = "tcp"
+    ports    = [22]
+  }
+}
+
+resource "google_compute_firewall" "allow_public_icmp" {
+  name          = "allow-public-icmp"
+  network       = "${google_compute_network.main.name}"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["nat", "bastion"]
+
+  project = "${var.project}"
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+resource "google_compute_firewall" "allow_internal" {
+  name    = "allow-internal"
+  network = "${google_compute_network.main.name}"
+
+  source_ranges = [
+    "${google_compute_subnetwork.public.ip_cidr_range}",
+    "${google_compute_subnetwork.workers.ip_cidr_range}",
+  ]
+
+  project = "${var.project}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+}
+
+resource "google_compute_firewall" "allow_jobs_nat" {
+  name    = "allow-jobs-nat"
+  network = "${google_compute_network.main.name}"
+
+  source_ranges = [
+    "${google_compute_subnetwork.jobs_org.ip_cidr_range}",
+    "${google_compute_subnetwork.jobs_com.ip_cidr_range}",
+  ]
+
+  target_tags = ["nat"]
+
+  project = "${var.project}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+}
+
+resource "google_compute_firewall" "deny_target_ip" {
+  name    = "deny-target-ip"
+  network = "${google_compute_network.main.name}"
+
+  direction          = "EGRESS"
+  destination_ranges = ["${var.deny_target_ip_ranges}"]
+
+  project = "${var.project}"
+
+  # highest priority
+  priority = "1000"
+
+  deny {
+    protocol = "tcp"
+  }
+
+  deny {
+    protocol = "udp"
+  }
+
+  deny {
+    protocol = "icmp"
+  }
+}
+
+resource "google_compute_address" "nat-b" {
+  name    = "nat-b"
+  region  = "us-central1"
+  project = "${var.project}"
+}
+
+resource "aws_route53_record" "nat-b" {
+  zone_id = "${var.travisci_net_external_zone_id}"
+  name    = "nat-${var.env}-${var.index}.gce-us-central1-b.travisci.net"
+  type    = "A"
+  ttl     = 5
+
+  records = [
+    "${google_compute_address.nat-b.address}",
+  ]
+}
+
+data "template_file" "nat_cloud_config" {
+  template = "${file("${path.module}/nat-cloud-config.yml.tpl")}"
+
+  vars {
+    nat_config       = "${var.nat_config}"
+    cloud_init_bash  = "${file("${path.module}/nat-cloud-init.bash")}"
+    github_users_env = "export GITHUB_USERS='${var.github_users}'"
+    syslog_address   = "${var.syslog_address}"
+  }
+}
+
+resource "google_compute_instance" "nat-b" {
+  name         = "${var.env}-${var.index}-nat-b"
+  machine_type = "${var.nat_machine_type}"
+  zone         = "us-central1-b"
+  tags         = ["nat", "${var.env}"]
+  project      = "${var.project}"
+
+  boot_disk {
+    auto_delete = true
+
+    initialize_params {
+      image = "${var.nat_image}"
+      type  = "pd-ssd"
+    }
+  }
+
+  network_interface {
+    subnetwork = "public"
+
+    access_config {
+      nat_ip = "${google_compute_address.nat-b.address}"
+    }
+  }
+
+  metadata {
+    "block-project-ssh-keys" = "true"
+    "user-data"              = "${data.template_file.nat_cloud_config.rendered}"
+  }
+}
+
+resource "google_compute_address" "bastion-b" {
+  name    = "bastion-b"
+  region  = "us-central1"
+  project = "${var.project}"
+}
+
+resource "aws_route53_record" "bastion-b" {
+  zone_id = "${var.travisci_net_external_zone_id}"
+  name    = "bastion-${var.env}-${var.index}.gce-us-central1-b.travisci.net"
+  type    = "A"
+  ttl     = 5
+
+  records = [
+    "${google_compute_address.bastion-b.address}",
+  ]
+}
+
+data "template_file" "bastion_cloud_config" {
+  template = "${file("${path.module}/bastion-cloud-config.yml.tpl")}"
+
+  vars {
+    bastion_config   = "${var.bastion_config}"
+    cloud_init_bash  = "${file("${path.module}/bastion-cloud-init.bash")}"
+    github_users_env = "export GITHUB_USERS='${var.github_users}'"
+    syslog_address   = "${var.syslog_address}"
+  }
+}
+
+resource "google_compute_instance" "bastion-b" {
+  name         = "${var.env}-${var.index}-bastion-b"
+  machine_type = "g1-small"
+  zone         = "us-central1-b"
+  tags         = ["bastion", "${var.env}"]
+  project      = "${var.project}"
+
+  boot_disk {
+    auto_delete = true
+
+    initialize_params {
+      image = "${var.bastion_image}"
+      type  = "pd-ssd"
+    }
+  }
+
+  network_interface {
+    subnetwork = "public"
+
+    access_config {
+      nat_ip = "${google_compute_address.bastion-b.address}"
+    }
+  }
+
+  metadata {
+    "block-project-ssh-keys" = "true"
+    "user-data"              = "${data.template_file.bastion_cloud_config.rendered}"
+  }
+}
+
+output "gce_subnetwork_public" {
+  value = "${google_compute_subnetwork.public.self_link}"
+}

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -93,6 +93,18 @@ resource "google_compute_subnetwork" "jobs_com" {
   project = "${var.project}"
 }
 
+resource "google_compute_firewall" "allow_main_ssh" {
+  name          = "allow-main-ssh"
+  network       = "${google_compute_network.main.name}"
+  source_ranges = ["87.142.116.219"]
+  priority      = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = [22]
+  }
+}
+
 resource "google_compute_firewall" "allow_public_ssh" {
   name          = "allow-public-ssh"
   network       = "${google_compute_network.main.name}"
@@ -403,4 +415,8 @@ resource "google_compute_instance" "bastion" {
 
 output "gce_subnetwork_public" {
   value = "${google_compute_subnetwork.public.self_link}"
+}
+
+output "gce_subnetwork_workers" {
+  value = "${google_compute_subnetwork.workers.self_link}"
 }

--- a/modules/gce_net/nat-cloud-config.yml.tpl
+++ b/modules/gce_net/nat-cloud-config.yml.tpl
@@ -8,10 +8,17 @@ write_files:
 - content: '${base64encode(nat_config)}'
   encoding: b64
   path: /etc/default/nat
+- content: '${base64encode(file("${assets}/nat/travis-nat-health-check"))}'
+  encoding: b64
+  path: /usr/local/bin/travis-nat-health-check
+  permissions: '0750'
 - content: '${base64encode(cloud_init_bash)}'
   encoding: b64
   path: /var/lib/cloud/scripts/per-instance/99-nat-cloud-init
   permissions: '0750'
+- content: '${base64encode(file("${assets}/nat/travis-nat-health-check.service"))}'
+  encoding: b64
+  path: /var/tmp/travis-nat-health-check.service
 - content: '${base64encode(syslog_address)}'
   encoding: b64
   path: /var/tmp/travis-run.d/syslog-address

--- a/modules/gce_net/nat-cloud-config.yml.tpl
+++ b/modules/gce_net/nat-cloud-config.yml.tpl
@@ -1,0 +1,17 @@
+#cloud-config
+# vim:filetype=yaml
+
+write_files:
+- content: '${base64encode(github_users_env)}'
+  encoding: b64
+  path: /etc/default/github-users
+- content: '${base64encode(nat_config)}'
+  encoding: b64
+  path: /etc/default/nat
+- content: '${base64encode(cloud_init_bash)}'
+  encoding: b64
+  path: /var/lib/cloud/scripts/per-instance/99-nat-cloud-init
+  permissions: '0750'
+- content: '${base64encode(syslog_address)}'
+  encoding: b64
+  path: /var/tmp/travis-run.d/syslog-address

--- a/modules/gce_net/nat-cloud-init.bash
+++ b/modules/gce_net/nat-cloud-init.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# vim:filetype=sh
+set -o errexit
+
+main() {
+  # shellcheck source=/dev/null
+  source /etc/default/nat
+  __write_duo_configs \
+    "$GCE_NAT_DUO_INTEGRATION_KEY" \
+    "$GCE_NAT_DUO_SECRET_KEY" \
+    "$GCE_NAT_DUO_API_HOSTNAME"
+}
+
+__write_duo_configs() {
+  for conf in /etc/duo/login_duo.conf /etc/duo/pam_duo.conf; do
+    cat >"$conf" <<EOF
+# Written by cloud-init $(date -u) :heart:
+[duo]
+ikey = $1
+skey = $2
+host = $3
+failmode = secure
+EOF
+  done
+}
+
+main "$@"

--- a/modules/gce_net/nat-cloud-init.bash
+++ b/modules/gce_net/nat-cloud-init.bash
@@ -3,25 +3,39 @@
 set -o errexit
 
 main() {
+  : "${VARTMP:=/var/tmp}"
+  : "${ETCDIR:=/etc}"
+
   # shellcheck source=/dev/null
-  source /etc/default/nat
+  source "${ETCDIR}/default/nat"
   __write_duo_configs \
-    "$GCE_NAT_DUO_INTEGRATION_KEY" \
-    "$GCE_NAT_DUO_SECRET_KEY" \
-    "$GCE_NAT_DUO_API_HOSTNAME"
+    "${GCE_NAT_DUO_INTEGRATION_KEY}" \
+    "${GCE_NAT_DUO_SECRET_KEY}" \
+    "${GCE_NAT_DUO_API_HOSTNAME}"
+
+  local service_src="${VARTMP}/travis-nat-health-check.service"
+  local service_dest="${ETCDIR}/systemd/system/travis-nat-health-check.service"
+
+  if [[ -f "${service_src}" && -d "$(dirname "${service_dest}")" ]]; then
+    cp -v "${service_src}" "${service_dest}"
+
+    systemctl enable travis-nat-health-check || true
+    systemctl start travis-nat-health-check || true
+  fi
 }
 
 __write_duo_configs() {
-  for conf in /etc/duo/login_duo.conf /etc/duo/pam_duo.conf; do
-    cat >"$conf" <<EOF
+  mkdir -p "${ETCDIR}/duo"
+  for conf in "${ETCDIR}/duo/login_duo.conf" "${ETCDIR}/duo/pam_duo.conf"; do
+    cat >"${conf}" <<EOF
 # Written by cloud-init $(date -u) :heart:
 [duo]
-ikey = $1
-skey = $2
-host = $3
+ikey = ${1}
+skey = ${2}
+host = ${3}
 failmode = secure
 EOF
   done
 }
 
-main "$@"
+main "${@}"

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -351,8 +351,7 @@ module "gce_worker_a" {
   syslog_address_org       = "${var.syslog_address_org}"
   worker_docker_self_image = "${var.worker_docker_self_image}"
   worker_image             = "${var.worker_image}"
-  zone                     = "us-central1-a"
-  zone_suffix              = "a"
+  zones                    = ["a"]
 }
 
 module "gce_worker_b" {
@@ -369,13 +368,13 @@ module "gce_worker_b" {
   instance_count_org       = "${var.worker_instance_count_org / var.zone_count}"
   machine_type             = "g1-small"
   project                  = "${var.project}"
+  region                   = "${var.region}"
   subnetwork_workers       = "${google_compute_subnetwork.workers.self_link}"
   syslog_address_com       = "${var.syslog_address_com}"
   syslog_address_org       = "${var.syslog_address_org}"
   worker_docker_self_image = "${var.worker_docker_self_image}"
   worker_image             = "${var.worker_image}"
-  zone                     = "us-central1-b"
-  zone_suffix              = "b"
+  zones                    = ["b"]
 }
 
 module "gce_worker_c" {
@@ -392,13 +391,13 @@ module "gce_worker_c" {
   instance_count_org       = "${var.worker_instance_count_org / var.zone_count}"
   machine_type             = "g1-small"
   project                  = "${var.project}"
+  region                   = "${var.region}"
   subnetwork_workers       = "${google_compute_subnetwork.workers.self_link}"
   syslog_address_com       = "${var.syslog_address_com}"
   syslog_address_org       = "${var.syslog_address_org}"
   worker_docker_self_image = "${var.worker_docker_self_image}"
   worker_image             = "${var.worker_image}"
-  zone                     = "us-central1-c"
-  zone_suffix              = "c"
+  zones                    = ["c"]
 }
 
 module "gce_worker_f" {
@@ -420,8 +419,8 @@ module "gce_worker_f" {
   syslog_address_org       = "${var.syslog_address_org}"
   worker_docker_self_image = "${var.worker_docker_self_image}"
   worker_image             = "${var.worker_image}"
-  zone                     = "us-central1-f"
-  zone_suffix              = "f"
+  region                   = "${var.region}"
+  zones                    = ["f"]
 }
 
 resource "heroku_app" "gcloud_cleanup" {

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -30,6 +30,11 @@ variable "github_users" {}
 variable "heroku_org" {}
 variable "index" {}
 variable "project" {}
+
+variable "region" {
+  default = "us-central1"
+}
+
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 variable "travisci_net_external_zone_id" {}
@@ -93,7 +98,7 @@ resource "google_compute_subnetwork" "public" {
   name          = "public"
   ip_cidr_range = "${var.public_subnet_cidr_range}"
   network       = "${google_compute_network.main.self_link}"
-  region        = "us-central1"
+  region        = "${var.region}"
 
   project = "${var.project}"
 }
@@ -106,7 +111,7 @@ resource "google_compute_subnetwork" "workers" {
   name          = "workers"
   ip_cidr_range = "${var.workers_subnet_cidr_range}"
   network       = "${google_compute_network.main.self_link}"
-  region        = "us-central1"
+  region        = "${var.region}"
 
   project = "${var.project}"
 }
@@ -115,7 +120,7 @@ resource "google_compute_subnetwork" "jobs_org" {
   name          = "jobs-org"
   ip_cidr_range = "${var.jobs_org_subnet_cidr_range}"
   network       = "${google_compute_network.main.self_link}"
-  region        = "us-central1"
+  region        = "${var.region}"
 
   project = "${var.project}"
 }
@@ -125,7 +130,7 @@ resource "google_compute_subnetwork" "build_org" {
   name          = "buildorg"
   ip_cidr_range = "${var.build_org_subnet_cidr_range}"
   network       = "${google_compute_network.main.self_link}"
-  region        = "us-central1"
+  region        = "${var.region}"
 
   project = "${var.project}"
 }
@@ -134,7 +139,7 @@ resource "google_compute_subnetwork" "jobs_com" {
   name          = "jobs-com"
   ip_cidr_range = "${var.jobs_com_subnet_cidr_range}"
   network       = "${google_compute_network.main.self_link}"
-  region        = "us-central1"
+  region        = "${var.region}"
 
   project = "${var.project}"
 }
@@ -144,7 +149,7 @@ resource "google_compute_subnetwork" "build_com" {
   name          = "buildcom"
   ip_cidr_range = "${var.build_com_subnet_cidr_range}"
   network       = "${google_compute_network.main.self_link}"
-  region        = "us-central1"
+  region        = "${var.region}"
 
   project = "${var.project}"
 }
@@ -253,7 +258,7 @@ resource "google_compute_firewall" "deny_target_ip" {
 
 resource "google_compute_address" "nat-b" {
   name    = "nat-b"
-  region  = "us-central1"
+  region  = "${var.region}"
   project = "${var.project}"
 }
 
@@ -270,7 +275,7 @@ resource "aws_route53_record" "nat-b" {
 
 resource "google_compute_address" "bastion-b" {
   name    = "bastion-b"
-  region  = "us-central1"
+  region  = "${var.region}"
   project = "${var.project}"
 }
 
@@ -340,6 +345,7 @@ module "gce_worker_a" {
   instance_count_org       = "${var.worker_instance_count_org / var.zone_count}"
   machine_type             = "g1-small"
   project                  = "${var.project}"
+  region                   = "${var.region}"
   subnetwork_workers       = "${google_compute_subnetwork.workers.self_link}"
   syslog_address_com       = "${var.syslog_address_com}"
   syslog_address_org       = "${var.syslog_address_org}"

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -13,13 +13,16 @@ variable "machine_type" {
 }
 
 variable "project" {}
+variable "region" {}
 variable "subnetwork_workers" {}
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 variable "worker_docker_self_image" {}
 variable "worker_image" {}
-variable "zone" {}
-variable "zone_suffix" {}
+
+variable "zones" {
+  default = ["a", "b", "c", "f"]
+}
 
 data "template_file" "cloud_init_env_com" {
   template = <<EOF
@@ -56,10 +59,11 @@ EOF
 }
 
 resource "google_compute_instance" "worker_com" {
-  count        = "${var.instance_count_com}"
-  name         = "${var.env}-${var.index}-worker-com-${var.zone_suffix}-${count.index + 1}-gce"
+  count = "${var.instance_count_com}"
+  name  = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
+
   machine_type = "${var.machine_type}"
-  zone         = "${var.zone}"
+  zone         = "${var.region}-${element(var.zones, count.index % length(var.zones))}"
   tags         = ["worker", "${var.env}", "com"]
   project      = "${var.project}"
 
@@ -127,10 +131,11 @@ EOF
 }
 
 resource "google_compute_instance" "worker_org" {
-  count        = "${var.instance_count_org}"
-  name         = "${var.env}-${var.index}-worker-org-${var.zone_suffix}-${count.index + 1}-gce"
+  count = "${var.instance_count_org}"
+  name  = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
+
   machine_type = "${var.machine_type}"
-  zone         = "${var.zone}"
+  zone         = "${var.region}-${element(var.zones, count.index % length(var.zones))}"
   tags         = ["worker", "${var.env}", "org"]
   project      = "${var.project}"
 

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -1,0 +1,115 @@
+variable "env" {}
+variable "gcloud_cleanup_account_json" {}
+
+variable "gcloud_cleanup_instance_filters" {
+  default = "name eq ^(testing-gce|travis-job).*"
+}
+
+variable "gcloud_cleanup_instance_max_age" {
+  default = "3h"
+}
+
+variable "gcloud_cleanup_job_board_url" {}
+
+variable "gcloud_cleanup_loop_sleep" {
+  default = "1s"
+}
+
+variable "gcloud_cleanup_scale" {
+  default = "worker=1:Standard-1X"
+}
+
+variable "gcloud_cleanup_version" {
+  default = "master"
+}
+
+variable "gcloud_zone" {}
+variable "github_users" {}
+variable "heroku_org" {}
+variable "index" {}
+variable "project" {}
+variable "syslog_address_com" {}
+variable "syslog_address_org" {}
+variable "travisci_net_external_zone_id" {}
+variable "worker_account_json_com" {}
+variable "worker_account_json_org" {}
+variable "worker_config_com" {}
+variable "worker_config_org" {}
+
+variable "worker_docker_self_image" {
+  default = "travisci/worker:v3.4.0"
+}
+
+variable "worker_image" {}
+variable "worker_instance_count_com" {}
+variable "worker_instance_count_org" {}
+
+variable "worker_machine_type" {
+  default = "g1-small"
+}
+
+variable "worker_subnetwork" {}
+
+variable "worker_zones" {
+  default = ["a", "b", "c", "f"]
+}
+
+module "gce_workers" {
+  source = "../gce_worker"
+
+  count                    = "${length(var.worker_zones)}"
+  account_json_com         = "${var.worker_account_json_com}"
+  account_json_org         = "${var.worker_account_json_org}"
+  config_com               = "${var.worker_config_com}"
+  config_org               = "${var.worker_config_org}"
+  env                      = "${var.env}"
+  github_users             = "${var.github_users}"
+  index                    = "${var.index}"
+  instance_count_com       = "${var.worker_instance_count_com / length(var.worker_zones)}"
+  instance_count_org       = "${var.worker_instance_count_org / length(var.worker_zones)}"
+  machine_type             = "${var.worker_machine_type}"
+  project                  = "${var.project}"
+  subnetwork_workers       = "${var.worker_subnetwork}"
+  syslog_address_com       = "${var.syslog_address_com}"
+  syslog_address_org       = "${var.syslog_address_org}"
+  worker_docker_self_image = "${var.worker_docker_self_image}"
+  worker_image             = "${var.worker_image}"
+  zone                     = "${var.region}-${element(var.worker_zones, count.index)}"
+  zone_suffix              = "${element(var.worker_zones, count.index)}"
+}
+
+resource "heroku_app" "gcloud_cleanup" {
+  name   = "gcloud-cleanup-${var.env}-${var.index}"
+  region = "us"
+
+  organization {
+    name = "${var.heroku_org}"
+  }
+
+  config_vars {
+    BUILDPACK_URL                   = "https://github.com/travis-ci/heroku-buildpack-makey-go"
+    GCLOUD_CLEANUP_ACCOUNT_JSON     = "${var.gcloud_cleanup_account_json}"
+    GCLOUD_CLEANUP_ENTITIES         = "instances"
+    GCLOUD_CLEANUP_INSTANCE_FILTERS = "${var.gcloud_cleanup_instance_filters}"
+    GCLOUD_CLEANUP_INSTANCE_MAX_AGE = "${var.gcloud_cleanup_instance_max_age}"
+    GCLOUD_CLEANUP_JOB_BOARD_URL    = "${var.gcloud_cleanup_job_board_url}"
+    GCLOUD_CLEANUP_LOOP_SLEEP       = "${var.gcloud_cleanup_loop_sleep}"
+    GCLOUD_LOG_HTTP                 = "no-log-http"
+    GCLOUD_PROJECT                  = "${var.project}"
+    GCLOUD_ZONE                     = "${var.gcloud_zone}"
+    GO_IMPORT_PATH                  = "github.com/travis-ci/gcloud-cleanup"
+  }
+}
+
+resource "null_resource" "gcloud_cleanup" {
+  triggers {
+    config_signature = "${sha256(join(",", values(heroku_app.gcloud_cleanup.config_vars.0)))}"
+    heroku_id        = "${heroku_app.gcloud_cleanup.id}"
+    ps_scale         = "${var.gcloud_cleanup_scale}"
+    version          = "${var.gcloud_cleanup_version}"
+  }
+
+  provisioner "local-exec" {
+    command = "exec ${path.module}/../../bin/heroku-wait-deploy-scale travis-ci/gcloud-cleanup ${heroku_app.gcloud_cleanup.id} ${var.gcloud_cleanup_scale} ${var.gcloud_cleanup_version}"
+  }
+}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current production (and staging) job VM instances all have public IP addresses, which makes it difficult (impossible?) to monitor or alter their respective network traffic.

## What approach did you choose and why?

(Re)introduce NAT to GCE, mostly, by reviving elder work and doing stuff per [GCE docs](https://cloud.google.com/vpc/docs/special-configurations#multiple-natgateways).

## How can you test this?

Bring up an instance manually with the `no-ip` tag and verify the routing through a NAT host.

<del>
**NOTE**: ⚠️ I believe the current state of this PR is unsafe for use with the `gce-production-.*` projects without destroying stuff that should not be destroyed.
</del>