### PR TITLE
Ensure NAT host routing and iptables work correctly

### DIFF
--- a/modules/gce_net/nat-cloud-config.yml.tpl
+++ b/modules/gce_net/nat-cloud-config.yml.tpl
@@ -14,7 +14,7 @@ write_files:
   permissions: '0750'
 - content: '${base64encode(cloud_init_bash)}'
   encoding: b64
-  path: /var/lib/cloud/scripts/per-instance/99-nat-cloud-init
+  path: /var/lib/cloud/scripts/per-boot/99-nat-cloud-init
   permissions: '0750'
 - content: '${base64encode(file("${assets}/nat/travis-nat-health-check.service"))}'
   encoding: b64
@@ -22,3 +22,6 @@ write_files:
 - content: '${base64encode(syslog_address)}'
   encoding: b64
   path: /var/tmp/travis-run.d/syslog-address
+
+runcmd:
+- [/var/lib/cloud/scripts/per-boot/99-nat-cloud-init]


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The GCE route and iptables configurations are not allowing traffic to route from job VMs through NAT hosts.

## What approach did you choose and why?

Switch to using `allow { protocol = "all" }` where applicable so that all traffic can get through.
Move the cloud-init script from per-instance to per-boot so that restarts result in refresh iptables configuration.

## How can you test this?

Via a test instance tagged `no-ip`, e.g.:

```
meatballhat@dan-no-ip-test:~$ sudo mtr --report www.google.com
Start: Wed Feb  7 23:24:06 2018
HOST: dan-no-ip-test              Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- nat-vm2m.c.travis-staging  0.0%    10    0.3   0.4   0.2   1.1   0.0
  2.|-- 74.125.124.105             0.0%    10    0.6   0.7   0.5   1.5   0.0
```