### PR TITLE
Upgrade worker to version 3.5.0

### DIFF
--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.4.0"
+  default = "v3.5.0"
 }
 
 data "template_file" "worker_config_common" {

--- a/macstadium-pod-2/workers.tf
+++ b/macstadium-pod-2/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.4.0"
+  default = "v3.5.0"
 }
 
 data "template_file" "worker_config_common" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -118,7 +118,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.4.0"
+  default = "travisci/worker:v3.5.0"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -44,7 +44,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.4.0"
+  default = "travisci/worker:v3.5.0"
 }
 
 variable "worker_image" {}

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -38,7 +38,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.4.0"
+  default = "travisci/worker:v3.5.0"
 }
 
 variable "worker_image" {}

--- a/modules/packet_worker/main.tf
+++ b/modules/packet_worker/main.tf
@@ -38,7 +38,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.4.0"
+  default = "travisci/worker:v3.5.0"
 }
 
 data "template_file" "cloud_init_env" {


### PR DESCRIPTION
Version 3.5.0 of the worker is still brewing (https://github.com/travis-ci/worker/pull/434), but it should be released into the wild soon. 😸 