### PR TITLE
Remove worker version override for packet

### DIFF
--- a/packet-staging-1/main.tf
+++ b/packet-staging-1/main.tf
@@ -25,10 +25,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.0.2"
-}
-
 terraform {
   backend "s3" {
     bucket         = "travis-terraform-state"
@@ -108,7 +104,6 @@ module "packet_workers_com" {
   worker_docker_image_php     = "${var.latest_docker_image_garnet}"
   worker_docker_image_python  = "${var.latest_docker_image_garnet}"
   worker_docker_image_ruby    = "${var.latest_docker_image_garnet}"
-  worker_docker_self_image    = "${var.latest_docker_image_worker}"
 }
 
 module "packet_workers_org" {
@@ -136,7 +131,6 @@ module "packet_workers_org" {
   worker_docker_image_php     = "${var.latest_docker_image_garnet}"
   worker_docker_image_python  = "${var.latest_docker_image_garnet}"
   worker_docker_image_ruby    = "${var.latest_docker_image_garnet}"
-  worker_docker_self_image    = "${var.latest_docker_image_worker}"
 }
 
 resource "aws_route53_record" "nat" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

This worker version override is not in use and now lags behind the version specified elsewhere, creating a potentially confusing `git grep` result.

## What approach did you choose and why?

Remove the override so that the default is used, as is the case on other infrastructures.

## How can you test this?

👀 