### PR TITLE
Adjust values to newer terraform defaults

### DIFF
--- a/bin/generate-latest-gce-images
+++ b/bin/generate-latest-gce-images
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'json'
 
 DEFAULT_GCE_PROJECT_ID = 'eco-emissary-99515'
 DEFAULT_IMAGE_PREFIXES = 'bastion nat tfw'
@@ -15,7 +16,7 @@ def main(argv: ARGV)
 
   prefixes.each do |prefix|
     name = fetch_latest_image_name(prefix, project)
-    $stdout.puts %[latest_gce_#{prefix}_image = "#{project}/#{name}"]
+    $stdout.puts %[latest_gce_#{prefix}_image = "#{name}"]
   end
 
   0
@@ -26,10 +27,11 @@ def fetch_latest_image_name(prefix, project)
     gcloud compute images list
     --project=#{project}
     --filter='name~^#{prefix}-'
-    --format='value(name)'
+    --format=json
   ].join(' ')
-  names = `#{command}`.split.map(&:strip)
-  names.sort.last
+  images = JSON.parse(`#{command}`)
+  images.sort! { |a, b| a.fetch('name') <=> b.fetch('name') }
+  images.last.fetch('selfLink')
 end
 
 def usage

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -1,9 +1,11 @@
+variable "deny_target_ip_ranges" {}
+
 variable "env" {
   default = "production"
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}
@@ -22,8 +24,6 @@ variable "travisci_net_external_zone_id" {
 
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
-
-variable "deny_target_ip_ranges" {}
 
 terraform {
   backend "s3" {

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -12,7 +12,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -12,7 +12,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -3,7 +3,7 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -1,3 +1,5 @@
+variable "deny_target_ip_ranges" {}
+
 variable "env" {
   default = "production"
 }
@@ -22,8 +24,6 @@ variable "travisci_net_external_zone_id" {
 
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
-
-variable "deny_target_ip_ranges" {}
 
 terraform {
   backend "s3" {

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -5,7 +5,7 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -12,7 +12,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -5,7 +5,7 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -12,7 +12,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -5,7 +5,7 @@ variable "env" {
 }
 
 variable "gce_bastion_image" {
-  default = "eco-emissary-99515/bastion-1496867305"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1496867305"
 }
 
 variable "gce_gcloud_zone" {}

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -12,7 +12,7 @@ variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "gce_worker_image" {
-  default = "eco-emissary-99515/tfw-1516675156-0b5be43"
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1516675156-0b5be43"
 }
 
 variable "github_users" {}

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -157,6 +157,7 @@ resource "google_compute_subnetwork" "build_com" {
 resource "google_compute_firewall" "allow_public_ssh" {
   name          = "allow-public-ssh"
   network       = "${google_compute_network.main.name}"
+  direction     = "INGRESS"
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["bastion"]
 
@@ -171,6 +172,7 @@ resource "google_compute_firewall" "allow_public_ssh" {
 resource "google_compute_firewall" "allow_public_icmp" {
   name          = "allow-public-icmp"
   network       = "${google_compute_network.main.name}"
+  direction     = "INGRESS"
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["nat", "bastion"]
 
@@ -182,8 +184,9 @@ resource "google_compute_firewall" "allow_public_icmp" {
 }
 
 resource "google_compute_firewall" "allow_internal" {
-  name    = "allow-internal"
-  network = "${google_compute_network.main.name}"
+  name      = "allow-internal"
+  network   = "${google_compute_network.main.name}"
+  direction = "INGRESS"
 
   source_ranges = [
     "${google_compute_subnetwork.public.ip_cidr_range}",
@@ -206,8 +209,9 @@ resource "google_compute_firewall" "allow_internal" {
 }
 
 resource "google_compute_firewall" "allow_jobs_nat" {
-  name    = "allow-jobs-nat"
-  network = "${google_compute_network.main.name}"
+  name      = "allow-jobs-nat"
+  network   = "${google_compute_network.main.name}"
+  direction = "INGRESS"
 
   source_ranges = [
     "${google_compute_subnetwork.jobs_org.ip_cidr_range}",
@@ -314,6 +318,7 @@ resource "google_compute_instance" "bastion-b" {
     initialize_params {
       image = "${var.bastion_image}"
       type  = "pd-ssd"
+      size  = 10
     }
   }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Running `make plan` with Terraform v0.11.x results in unexpected changes, including re-creating all firewall rules that do not explicitly set `direction` and re-creating the bastion host due to mismatched image specification.

## What approach did you choose and why?

- Update the resource values to match existing state so that no changes are planned.
- Update the latest GCE image generation script to specify "self-link" values instead of "{project}/{name}"

## How can you test this?

Run a `make plan` in any of the `gce-production-.*` dirs.