### PR TITLE
tweak date format for honeytail

### DIFF
--- a/modules/aws_asg/kill-old-containers.bash
+++ b/modules/aws_asg/kill-old-containers.bash
@@ -5,7 +5,7 @@ set -o pipefail
 __logger() {
   level="$1" && shift
   msg="$1" && shift
-  date="$(date -u +%Y%m%dT%H%M%S)"
+  date="$(date --iso-8601=seconds)"
   log_msg="tag=cron time=$date level=$level msg=\"$msg\" $*"
   logger -t kill-old-containers "$log_msg"
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Before:
```
Feb 21 09:39:01 i-0c32207-staging-1-worker-org-ec2 kill-old-containers: tag=cron time=20180221T153901 level=info msg="cron finished" status=noop killed=0 running=4
```

After:
```
Feb 21 09:39:01 i-0c32207-staging-1-worker-org-ec2 kill-old-containers: tag=cron time=2018-02-21T09:45:56-06:00 level=info msg="cron finished" status=noop killed=0 running=4
```

## What approach did you choose and why?
```
-  date="$(date -u +%Y%m%dT%H%M%S)"
+  date="$(date --iso-8601=seconds)"
```