### PR TITLE
Add script and config generation for running rolling NAT replacement

### DIFF
--- a/bin/gcloud-nat-rolling-update
+++ b/bin/gcloud-nat-rolling-update
@@ -39,14 +39,28 @@ def main
       #{instance_group} --max-surge=0 --zone=#{zone} --project=#{project}
       --version=template=#{groups_templates.fetch(instance_group)}
     ]
-    if options.fetch(:noop)
-      puts "---> NOOP: #{command.join(' ').inspect}"
-    else
-      puts "---> RUNNING: #{command.join(' ').inspect}"
-      system(*command)
-    end
+
+    run_command(command, options.fetch(:noop))
   end
+
+  groups.length.times do |i|
+    command = %W[
+      terraform taint -module=gce_net google_compute_route.nat.#{i}
+    ]
+
+    run_command(command, options.fetch(:noop))
+  end
+
   0
+end
+
+def run_command(command, noop)
+  if noop
+    puts "---> NOOP: #{command.join(' ').inspect}"
+  else
+    puts "---> RUNNING: #{command.join(' ').inspect}"
+    system(*command)
+  end
 end
 
 def source_env(env_file)

--- a/bin/gcloud-nat-rolling-update
+++ b/bin/gcloud-nat-rolling-update
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+require 'optparse'
+
+def main
+  options = { env: '', noop: false }
+  OptionParser.new do |opts|
+    opts.on('-E', '--env=ENV_FILE') do |f|
+      options[:env] = f.strip
+    end
+
+    opts.on('-n', '--noop') do
+      options[:noop] = true
+    end
+  end.parse!
+
+  env = Hash[ENV]
+  env.merge!(source_env(options[:env])) unless options[:env].empty?
+
+  project = env.fetch('GCE_NAT_ROLLING_UPDATER_PROJECT')
+  region = env.fetch('GCE_NAT_ROLLING_UPDATER_REGION')
+  templates = env.fetch('GCE_NAT_ROLLING_UPDATER_TEMPLATES').split(',').map(&:strip)
+  groups = env.fetch('GCE_NAT_ROLLING_UPDATER_GROUPS').split(',').map(&:strip)
+
+  groups_zones = groups.map do |group|
+    [group, "#{region}-#{group.split('-').fetch(1)}"]
+  end
+  groups_zones = Hash[groups_zones]
+
+  groups_templates = {}
+  templates.each do |t|
+    groups.each do |g|
+      groups_templates[g] = t if t =~ /.+#{g}-template-.+/
+    end
+  end
+
+  groups_zones.each do |instance_group, zone|
+    command = %W[
+      gcloud beta compute instance-groups managed rolling-action start-update
+      #{instance_group} --max-surge=0 --zone=#{zone} --project=#{project}
+      --version=template=#{groups_templates.fetch(instance_group)}
+    ]
+    if options.fetch(:noop)
+      puts "---> NOOP: #{command.join(' ').inspect}"
+    else
+      puts "---> RUNNING: #{command.join(' ').inspect}"
+      system(*command)
+    end
+  end
+  0
+end
+
+def source_env(env_file)
+  base_env = `bash -c 'printenv'`.split($/).map do |l|
+    l.strip.split('=', 2)
+  end
+  base_env = Hash[base_env]
+  sourced_env = `bash -c "source #{env_file}; printenv"`.split($/).map do |l|
+    l.strip.split('=', 2)
+  end
+  sourced_env = Hash[sourced_env]
+  base_env.keys.each { |k| sourced_env.delete(k) }
+  sourced_env
+end
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -302,7 +302,7 @@ resource "google_compute_firewall" "allow_nat_health_check" {
 resource "google_compute_instance_group_manager" "nat" {
   count = "${length(var.nat_zones) * var.nat_count_per_zone}"
 
-  base_instance_name = "nat-${var.env}-${var.index}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
+  base_instance_name = "${var.env}-${var.index}-nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
   instance_template  = "${element(google_compute_instance_template.nat.*.self_link, count.index)}"
   name               = "nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
   target_size        = 1

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -366,7 +366,7 @@ EOF
 
 resource "local_file" "nat_rolling_updater_config" {
   content  = "${data.template_file.nat_rolling_updater_config.rendered}"
-  filename = "${path.module}/../../tmp/nat-rolling-updater-${var.env}-${var.index}.env"
+  filename = "${path.cwd}/config/nat-rolling-updater-${var.env}-${var.index}.env"
 
   provisioner "local-exec" {
     command = "chmod 0644 ${local_file.nat_rolling_updater_config.filename}"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -229,7 +229,7 @@ data "template_file" "nat_cloud_config" {
     nat_conntracker_config = "${var.nat_conntracker_config}"
     cloud_init_bash        = "${file("${path.module}/nat-cloud-init.bash")}"
     github_users_env       = "export GITHUB_USERS='${var.github_users}'"
-    instance_hostname      = "nat-${var.env}-${var.index}.gce-___REGION_ZONE___.travisci.net"
+    instance_hostname      = "nat-${var.env}-${var.index}-___INSTANCE_ID___.gce-___REGION_ZONE___.travisci.net"
     syslog_address         = "${var.syslog_address}"
     assets                 = "${path.module}/../../assets"
   }

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -302,7 +302,7 @@ resource "google_compute_firewall" "allow_nat_health_check" {
 resource "google_compute_instance_group_manager" "nat" {
   count = "${length(var.nat_zones) * var.nat_count_per_zone}"
 
-  base_instance_name = "nat"
+  base_instance_name = "nat-${var.env}-${var.index}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
   instance_template  = "${element(google_compute_instance_template.nat.*.self_link, count.index)}"
   name               = "nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
   target_size        = 1


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Whenever a new instance template is assigned to the NAT managed instance groups, it does not (and should not) automatically trigger a rolling update.  This leaves performing the rolling update and subsequent `taint` + `plan` + `apply` to a human.

## What approach did you choose and why?

Write out a config file that captures the relevant variables out of terraform land and use it as input to a script that can trigger the rolling update and resource tainting.

## How can you test this?

It works!  (locally)  (probably)