### PR TITLE
Automate provisioning and configuration of nat-conntracker redis

### DIFF
--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -5,6 +5,7 @@ variable "env" {
 variable "latest_gce_bastion_image" {}
 variable "latest_gce_nat_image" {}
 
+variable "gce_heroku_org" {}
 variable "github_users" {}
 
 variable "index" {
@@ -42,6 +43,7 @@ provider "google" {
 }
 
 provider "aws" {}
+provider "heroku" {}
 
 module "gce_net" {
   source = "../modules/gce_net"
@@ -51,9 +53,11 @@ module "gce_net" {
   deny_target_ip_ranges         = ["${split(",", var.deny_target_ip_ranges)}"]
   env                           = "${var.env}"
   github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
   nat_config                    = "${file("config/nat.env")}"
   nat_conntracker_config        = "${file("nat-conntracker.env")}"
+  nat_conntracker_redis_plan    = "hobby-dev"
   nat_image                     = "${var.latest_gce_nat_image}"
   nat_machine_type              = "g1-small"
   project                       = "travis-staging-1"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -20,9 +20,14 @@ variable "gce_health_check_source_ranges" {
 }
 
 variable "github_users" {}
+variable "heroku_org" {}
 variable "index" {}
 variable "nat_config" {}
 variable "nat_conntracker_config" {}
+
+variable "nat_conntracker_redis_plan" {
+  default = "premium-0"
+}
 
 variable "nat_count_per_zone" {
   default = 1
@@ -221,17 +226,44 @@ resource "aws_route53_record" "nat_regional" {
   records = ["${google_compute_address.nat.*.address}"]
 }
 
+resource "heroku_app" "nat_conntracker" {
+  name   = "nat-conntracker-${var.env}-${var.index}"
+  region = "us"
+
+  organization {
+    name = "${var.heroku_org}"
+  }
+
+  config_vars {
+    MANAGED_VIA = "github.com/travis-ci/terraform-config"
+  }
+}
+
+resource "heroku_addon" "nat_conntracker_redis" {
+  app  = "${heroku_app.nat_conntracker.name}"
+  plan = "heroku-redis:${var.nat_conntracker_redis_plan}"
+}
+
 data "template_file" "nat_cloud_config" {
   template = "${file("${path.module}/nat-cloud-config.yml.tpl")}"
 
   vars {
-    nat_config             = "${var.nat_config}"
-    nat_conntracker_config = "${var.nat_conntracker_config}"
-    cloud_init_bash        = "${file("${path.module}/nat-cloud-init.bash")}"
-    github_users_env       = "export GITHUB_USERS='${var.github_users}'"
-    instance_hostname      = "nat-${var.env}-${var.index}-___INSTANCE_ID___.gce-___REGION_ZONE___.travisci.net"
-    syslog_address         = "${var.syslog_address}"
-    assets                 = "${path.module}/../../assets"
+    nat_config        = "${var.nat_config}"
+    cloud_init_bash   = "${file("${path.module}/nat-cloud-init.bash")}"
+    github_users_env  = "export GITHUB_USERS='${var.github_users}'"
+    instance_hostname = "nat-${var.env}-${var.index}-___INSTANCE_ID___.gce-___REGION_ZONE___.travisci.net"
+    syslog_address    = "${var.syslog_address}"
+    assets            = "${path.module}/../../assets"
+
+    nat_conntracker_config = <<EOF
+### nat-conntracker.env
+${var.nat_conntracker_config}
+
+### in-line
+export NAT_CONNTRACKER_REDIS_URL=${heroku_app.nat_conntracker.all_config_vars.REDIS_URL}
+export NAT_CONNTRACKER_REDIS_ADDON_NAME=${heroku_addon.nat_conntracker_redis.name}
+export NAT_CONNTRACKER_REDIS_APP_NAME=${heroku_app.nat_conntracker.name}
+EOF
   }
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current nat-conntracker configuration supports a redis URL, but no redis instance yet exists specifically for nat-conntracker.  I performed tests by using the `REDIS_URL` from `travis-staging`.

## What approach did you choose and why?

Provision an empty heroku app and attach a heroku redis instance to it, using the resulting `REDIS_URL` in configuration for nat-conntracker.

## How can you test this?

`make plan`, `make apply`, poke around in staging