### PR TITLE
Ensure fail2ban logs to syslog

### DIFF
--- a/assets/nat/var/tmp/nat-conntracker-confs/fail2ban.local
+++ b/assets/nat/var/tmp/nat-conntracker-confs/fail2ban.local
@@ -1,0 +1,2 @@
+[Definition]
+logtarget = SYSLOG

--- a/modules/gce_net/nat-cloud-init.bash
+++ b/modules/gce_net/nat-cloud-init.bash
@@ -148,6 +148,9 @@ __setup_nat_conntracker() {
   cp -v "${ncc}/fail2ban-jail-nat-conntracker.conf" \
     "${ETCDIR}/fail2ban/jail.d/nat-conntracker.conf"
 
+  cp -v "${ncc}/fail2ban.local" \
+    "${ETCDIR}/fail2ban/fail2ban.local"
+
   systemctl restart fail2ban
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Current fail2ban logs go to `/var/log/fail2ban.log`, which means that they don't end up in papertrail as there is no rsyslog file watcher for that path.

## What approach did you choose and why?

Add a file at `/etc/fail2ban/fail2ban.local` to override `logtarget = SYSLOG`.

## How can you test this?

- [x] working correctly when manually configured in staging (see https://papertrailapp.com/groups/4021403/events?q=program%3Afail2ban.filter)