### PR TITLE
Ensure nat-conntracker heroku app name includes infra hint

### DIFF
--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -227,7 +227,7 @@ resource "aws_route53_record" "nat_regional" {
 }
 
 resource "heroku_app" "nat_conntracker" {
-  name   = "nat-conntracker-${var.env}-${var.index}"
+  name   = "nat-conntracker-gce-${var.env == "production" ? "prod" : var.env}-${var.index}"
   region = "us"
 
   organization {
@@ -260,7 +260,7 @@ data "template_file" "nat_cloud_config" {
 ${var.nat_conntracker_config}
 
 ### in-line
-export NAT_CONNTRACKER_REDIS_URL=${heroku_app.nat_conntracker.all_config_vars.REDIS_URL}
+export NAT_CONNTRACKER_REDIS_URL=${lookup(heroku_app.nat_conntracker.all_config_vars, "REDIS_URL")}
 export NAT_CONNTRACKER_REDIS_ADDON_NAME=${heroku_addon.nat_conntracker_redis.name}
 export NAT_CONNTRACKER_REDIS_APP_NAME=${heroku_app.nat_conntracker.name}
 EOF


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The heroku apps created for nat-conntracker redis resources are named with `${var.env}` and `${var.index}` but nothing to indicate which infrastructure they're for.

## What approach did you choose and why?

Add a `gce` string and also ensure `"prod"` is used when `${var.env}` is `production` to stay under the heroku app name limit so that we can provision apps in the future for the `aws` infrastructure(s).

## How can you test this?

It works! :tada: (in `gce-staging-net-1`)