### PR TITLE
Specify key pair 'aj' on ASG instances

### DIFF
--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -217,6 +217,7 @@ resource "aws_launch_configuration" "workers" {
   name_prefix       = "${var.env}-${var.index}-workers-${var.site}-"
   image_id          = "${var.worker_ami}"
   instance_type     = "${var.worker_instance_type}"
+  key_name          = "aj"
   security_groups   = ["${var.security_groups}"]
   user_data         = "${data.template_cloudinit_config.cloud_config.rendered}"
   enable_monitoring = true


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Sometimes, instances are not able to complete cloud-init, which leaves them inaccessible.

## What approach did you choose and why?

Add my own key pair to the ASG launch configuration.

## How can you test this?

`make apply` in staging.

## What feedback would you like, if any?

I don't know a way to add more than one key pair! :(