### PR TITLE
Worker v3.6.0 rollout

### DIFF
--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.5.0"
+  default = "v3.6.0"
 }
 
 data "template_file" "worker_config_common" {

--- a/macstadium-pod-2/workers.tf
+++ b/macstadium-pod-2/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.5.0"
+  default = "v3.6.0"
 }
 
 data "template_file" "worker_config_common" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -118,7 +118,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.5.0"
+  default = "travisci/worker:v3.6.0"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -44,7 +44,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.5.0"
+  default = "travisci/worker:v3.6.0"
 }
 
 variable "worker_image" {}

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -38,7 +38,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.5.0"
+  default = "travisci/worker:v3.6.0"
 }
 
 variable "worker_image" {}

--- a/modules/packet_worker/main.tf
+++ b/modules/packet_worker/main.tf
@@ -38,7 +38,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.5.0"
+  default = "travisci/worker:v3.6.0"
 }
 
 data "template_file" "cloud_init_env" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Worker v3.6.0 is not yet deployed in all hosted infrastructures.

## What approach did you choose and why?

Bump the configured version to v3.6.0.

## How can you test this?

- [x] staging deployments