### PR TITLE
Only notify slack on production environments

### DIFF
--- a/bin/post-flight
+++ b/bin/post-flight
@@ -54,4 +54,6 @@ __git_diff_names() {
   popd &>/dev/null
 }
 
-main "$@"
+if [[ "$(pwd)" == *"production"* ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Notifications on `make apply` are a bit noisy!

## What approach did you choose and why?

Only notify if we're in a directory with `production` in the name.
