### PR TITLE
Scaling tweaks

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -40,7 +40,9 @@ terraform {
   }
 }
 
-provider "aws" {}
+provider "aws" {
+  version = "~> 1.4"
+}
 
 provider "heroku" {
   version = "0.1.0"

--- a/aws-shared-1/main.tf
+++ b/aws-shared-1/main.tf
@@ -63,7 +63,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "1.3.1"
+  version = "~> 1.4"
 }
 
 data "aws_ami" "nat" {

--- a/aws-shared-1/main.tf
+++ b/aws-shared-1/main.tf
@@ -62,7 +62,9 @@ terraform {
   }
 }
 
-provider "aws" {}
+provider "aws" {
+  version = "1.3.1"
+}
 
 data "aws_ami" "nat" {
   most_recent = true

--- a/aws-shared-2/main.tf
+++ b/aws-shared-2/main.tf
@@ -72,7 +72,9 @@ terraform {
   }
 }
 
-provider "aws" {}
+provider "aws" {
+  version = "~> 1.4"
+}
 
 data "aws_ami" "nat" {
   most_recent = true

--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -27,7 +27,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "1.3.1"
+  version = "~> 1.4"
 }
 
 provider "heroku" {

--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -26,7 +26,9 @@ terraform {
   }
 }
 
-provider "aws" {}
+provider "aws" {
+  version = "1.3.1"
+}
 
 provider "heroku" {
   version = "0.1.0"

--- a/bin/post-flight
+++ b/bin/post-flight
@@ -54,6 +54,6 @@ __git_diff_names() {
   popd &>/dev/null
 }
 
-if [[ "$(pwd)" == *"production"* ]]; then
+if [[ "$(pwd)" == *"production"* ]] || [[ "$(pwd)" == *"2"* ]]; then
   main "$@"
 fi

--- a/modules/aws_asg/dashboards.tf
+++ b/modules/aws_asg/dashboards.tf
@@ -31,11 +31,15 @@ resource "aws_cloudwatch_dashboard" "main" {
                         },
                         {
                             "label": "Remove ${var.worker_asg_scale_in_qty} instance",
-                            "value": "${var.worker_asg_scale_in_threshold}"
+                            "value": "${var.worker_asg_scale_in_threshold + 1}"
                         },
                         {
                             "label": "Remove ${var.worker_asg_scale_in_qty * 2} instances",
-                            "value": "${var.worker_asg_scale_in_threshold + ceil(var.worker_asg_scale_in_threshold / 2)}"
+                            "value": "${var.worker_asg_scale_in_threshold * 1.5}"
+                        },
+                        {
+                            "label": "Remove ${var.worker_asg_scale_in_qty * 3} instances",
+                            "value": "${var.worker_asg_scale_in_threshold * 2}"
                         },
                         {
                             "color": "#d62728",

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -317,6 +317,13 @@ resource "aws_autoscaling_policy" "workers_remove_capacity" {
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty * 2}"
     metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 2)}"
+    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 3)}"
+  }
+
+  # Headroom is way above scale-in threshold; remove n * 2 instances
+  step_adjustment {
+    scaling_adjustment          = "${var.worker_asg_scale_in_qty * 3}"
+    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 3)}"
   }
 }
 

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -310,20 +310,20 @@ resource "aws_autoscaling_policy" "workers_remove_capacity" {
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty}"
     metric_interval_lower_bound = 1.0
-    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 2)}"
+    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 4.0)}"
   }
 
   # Headroom is way above scale-in threshold; remove n * 2 instances
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty * 2}"
-    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 2)}"
-    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 3)}"
+    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 4.0)}"
+    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 3.0)}"
   }
 
   # Headroom is way above scale-in threshold; remove n * 2 instances
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty * 3}"
-    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 3)}"
+    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 3.0)}"
   }
 }
 

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -298,6 +298,7 @@ resource "aws_autoscaling_group" "workers" {
   }
 }
 
+/* Be sure to update modules/aws_asg/dashboards.tf when changing any of the bounds here. */
 resource "aws_autoscaling_policy" "workers_remove_capacity" {
   name                      = "${var.env}-${var.index}-workers-${var.site}-remove-capacity"
   adjustment_type           = "ChangeInCapacity"
@@ -310,20 +311,20 @@ resource "aws_autoscaling_policy" "workers_remove_capacity" {
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty}"
     metric_interval_lower_bound = 1.0
-    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 4.0)}"
+    metric_interval_upper_bound = "${var.worker_asg_scale_in_threshold * 1.5}"
   }
 
   # Headroom is way above scale-in threshold; remove n * 2 instances
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty * 2}"
-    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 4.0)}"
-    metric_interval_upper_bound = "${ceil(var.worker_asg_scale_in_threshold / 3.0)}"
+    metric_interval_lower_bound = "${var.worker_asg_scale_in_threshold * 1.5}"
+    metric_interval_upper_bound = "${var.worker_asg_scale_in_threshold * 2}"
   }
 
-  # Headroom is way above scale-in threshold; remove n * 2 instances
+  # Headroom is way above scale-in threshold; remove n * 3 instances
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty * 3}"
-    metric_interval_lower_bound = "${ceil(var.worker_asg_scale_in_threshold / 3.0)}"
+    metric_interval_lower_bound = "${var.worker_asg_scale_in_threshold * 2}"
   }
 }
 
@@ -339,6 +340,7 @@ resource "aws_cloudwatch_metric_alarm" "workers_remove_capacity" {
   alarm_actions       = ["${aws_autoscaling_policy.workers_remove_capacity.arn}"]
 }
 
+/* Be sure to update modules/aws_asg/dashboards.tf when changing any of the bounds here. */
 resource "aws_autoscaling_policy" "workers_add_capacity" {
   name                      = "${var.env}-${var.index}-workers-${var.site}-add-capacity"
   adjustment_type           = "ChangeInCapacity"

--- a/modules/aws_az/workers/main.tf
+++ b/modules/aws_az/workers/main.tf
@@ -1,3 +1,5 @@
+/* For changes to this file to take effect, run `make apply` in `aws-shared-{1,2}/`.  */
+
 variable "az" {}
 variable "az_group" {}
 variable "cidr_block" {}
@@ -72,7 +74,7 @@ resource "aws_instance" "nat" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "low_packets_out" {
-  alarm_description   = "This metric monitors outbound packets through NAT"
+  alarm_description   = "NetworkPacketsOut: NAT ${var.az_group} (${var.env}/${var.site})"
   alarm_name          = "low-packets-out-${aws_instance.nat.id}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "2"


### PR DESCRIPTION
- Pin AWS provider to version `~> 1.4`
- Add another threshold for faster scale-in.
- Update corresponding CloudWatch dashboard
- Add a few explanatory comments.

## What is the problem that this PR is trying to fix?

Sometimes our headroom spikes significantly and it takes a long time to bring it back down.

## What approach did you choose and why?

This PR adds another scale-in threshold to bring down headroom a bit faster.