### PR TITLE
Get the NAT hosts to forward traffic like a NAT

### DIFF
--- a/modules/gce_net/nat-cloud-init.bash
+++ b/modules/gce_net/nat-cloud-init.bash
@@ -91,14 +91,22 @@ __setup_nat_forwarding() {
   sysctl -w net.ipv4.ip_forward=1
 
   iptables -t nat -S POSTROUTING | grep -v 172. | if ! grep -q MASQUERADE; then
-    iptables -t nat -A POSTROUTING -o "${pub_iface}" -j MASQUERADE
+    iptables -t nat -I POSTROUTING -o "${pub_iface}" -j MASQUERADE
   fi
 
   iptables -S FORWARD | grep -v docker |
     if ! grep -qE 'conntrack.+RELATED,ESTABLISHED'; then
-      iptables -A FORWARD -o "${pub_iface}" \
+      iptables -I FORWARD -o "${pub_iface}" \
         -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     fi
+
+  iptables -P INPUT ACCEPT
+  iptables -P FORWARD ACCEPT
+  iptables -P OUTPUT ACCEPT
+  iptables -t nat -P PREROUTING ACCEPT
+  iptables -t nat -P INPUT ACCEPT
+  iptables -t nat -P OUTPUT ACCEPT
+  iptables -t nat -P POSTROUTING ACCEPT
 }
 
 __find_public_interface() {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

GCE NAT hosts are not NATting since switching to the tfw image, perhaps among other changes, which appears to have been due to an `iptables -P FORWARD DROP`, the source of which is currently unknown.

## What approach did you choose and why?

Make sure all of the policies in the `filter` and `nat` tables are set to `ACCEPT` :tada: 

## How can you test this?

- [x] staging deploy and testing