### PR TITLE
Bump the default docker image for nat-conntracker

### DIFF
--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -30,7 +30,7 @@ variable "nat_config" {}
 variable "nat_conntracker_config" {}
 
 variable "nat_conntracker_self_image" {
-  default = "travisci/nat-conntracker:0.3.0"
+  default = "travisci/nat-conntracker:0.4.0"
 }
 
 variable "nat_conntracker_redis_plan" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The default docker image tag for nat-conntracker does not contain the necessary systemd bits.

## What approach did you choose and why?

Set the default to `travisci/nat-conntracker:0.4.0` as it contains the expected systemd bits.