### PR TITLE
Adds librato source names for the collect-vsphere

### DIFF
--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -1,4 +1,5 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+include $(shell git rev-parse --show-toplevel)/trvs.mk
 
 PROD_TF_VERSION := v0.9.11
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -1,4 +1,5 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+include $(shell git rev-parse --show-toplevel)/trvs.mk
 
 PROD_TF_VERSION := v0.9.11
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/modules/collectd_vsphere/collectd_vsphere.tf
+++ b/modules/collectd_vsphere/collectd_vsphere.tf
@@ -87,6 +87,7 @@ resource "null_resource" "collectd_vsphere" {
 ${file(var.config_path)}
 export COLLECTD_VSPHERE_COLLECTD_USERNAME=${var.collectd_vsphere_collectd_network_user}
 export COLLECTD_VSPHERE_COLLECTD_PASSWORD=${var.collectd_vsphere_collectd_network_token}
+export COLLECTD_VSPHERE_LIBRATO_SOURCE='collectd-vsphere-${var.env}-${var.index}'
 EOF
 
     destination = "/tmp/etc-default-collectd-vsphere-${var.env}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Currently we're not reporting any collectd-metrics to Librato 

## What approach did you choose and why?
A source name was not explicit in the /modules/collect-vsphere/collectd-vsphere.tf

## How can you test this?
Terraform plan output

## What feedback would you like, if any?

The reason for the change to be implemented now is to get better visibility into usage / infra consumption to better understand capacity planning.  

@emdantrim has it on their schedule to do refactoring for collectd, vsphere-monitor, and vsphere-janitor next 2 weeks.  Should we wait until then for apply? 
