### PR TITLE
Bump to nat-conntracker 0.5.0

### DIFF
--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -30,7 +30,7 @@ variable "nat_config" {}
 variable "nat_conntracker_config" {}
 
 variable "nat_conntracker_self_image" {
-  default = "travisci/nat-conntracker:0.4.0"
+  default = "travisci/nat-conntracker:0.5.0"
 }
 
 variable "nat_conntracker_redis_plan" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current version of nat-conntracker in production is lacking some hotness.

## What approach did you choose and why?

Bump to nat-conntracker 0.5.0 to increase hotness.

## How can you test this?

- [x] gce-production-5 verification