### PR TITLE
Ensure GCE NATs have collectd

### DIFF
--- a/modules/gce_net/nat-cloud-init.bash
+++ b/modules/gce_net/nat-cloud-init.bash
@@ -45,6 +45,9 @@ __write_librato_config() {
     return
   fi
 
+  apt-get update -y
+  apt-get install -y collectd collectd-utils
+
   mkdir -p "${ETCDIR}/collectd/collectd.conf.d"
 
   local hostname_tmpl="${VARTMP}/travis-run.d/instance-hostname.tmpl"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The production GCE NATs are not sending stats anywhere :scream_cat:

## What approach did you choose and why?

If Librato configuration is available, install `collectd` and `collectd-utils` so that stats get written to Librato.

## How can you test this?

- [ ] production deploy into a single NAT instance via rolling replacement