### PR TITLE
Shrinks POOL_SIZE for org and com macstadium workers.

### DIFF
--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -1,4 +1,3 @@
-include $(shell git rev-parse --show-toplevel)/trvs.mk
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
 PROD_TF_VERSION := v0.9.11
@@ -87,6 +86,13 @@ $(CONFIG_FILES):
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 
+$(TRVS_INFRA_ENV_TFVARS):
+	trvs generate-config -f json terraform-config $(INFRA)_$(ENV_SHORT) >$@
+
+$(TRVS_ENV_NAME_TFVARS):
+	trvs generate-config -f json terraform-config $(subst -,_,$(ENV_NAME)) >$@
+	
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs-collectd-vsphere.auto.tfvars
+	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
+	

--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -1,4 +1,3 @@
-include $(shell git rev-parse --show-toplevel)/trvs.mk
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
 PROD_TF_VERSION := v0.9.11
@@ -34,8 +33,10 @@ CONFIG_FILES := \
 
 INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
+include $(shell git rev-parse --show-toplevel)/trvs.mk
+
 .PHONY: .config
-.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
+.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars trvs-collectd-vsphere.auto.tfvars
 
 $(CONFIG_FILES):
 	mkdir -p config
@@ -89,4 +90,7 @@ $(CONFIG_FILES):
 
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs-collectd-vsphere.auto.tfvars
+
+trvs-collectd-vsphere.auto.tfvars:
+	trvs generate-config -f json collectd-vsphere common-$(INDEX) -o $@
+

--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -1,3 +1,4 @@
+include $(shell git rev-parse --show-toplevel)/trvs.mk
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
 PROD_TF_VERSION := v0.9.11
@@ -88,4 +89,4 @@ $(CONFIG_FILES):
 
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
+	trvs-collectd-vsphere.auto.tfvars

--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -35,6 +35,7 @@ INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
 include $(shell git rev-parse --show-toplevel)/trvs.mk
 
+
 .PHONY: .config
 .config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars trvs-collectd-vsphere.auto.tfvars
 
@@ -88,7 +89,14 @@ $(CONFIG_FILES):
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 
-$(ENV_NAME).auto.tfvars:
+$(TERRAFORM) plan -module-depth=-1
+	var-file=macstadium-pod-1.auto.tfvars
+	var-file=trvs-collectd-vsphere.auto.tfvars
+	var-file=trvs-macstadium-pod-1.auto.tfvars
+	var-file=trvs-macstadium-pod.auto.tfvars
+ -out=$(TFPLAN)
+ 
+ $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
 
 trvs-collectd-vsphere.auto.tfvars:

--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -1,3 +1,4 @@
+include $(shell git rev-parse --show-toplevel)/trvs.mk
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
 PROD_TF_VERSION := v0.9.11
@@ -86,13 +87,6 @@ $(CONFIG_FILES):
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 
-$(TRVS_INFRA_ENV_TFVARS):
-	trvs generate-config -f json terraform-config $(INFRA)_$(ENV_SHORT) >$@
-
-$(TRVS_ENV_NAME_TFVARS):
-	trvs generate-config -f json terraform-config $(subst -,_,$(ENV_NAME)) >$@
-	
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
-	
+	trvs-collectd-vsphere.auto.tfvars

--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -98,7 +98,7 @@ plan: announce .config $(TRVS_TFVARS) $(TFSTATE)
 		-var-file=trvs-$(INFRA)-$(ENV_SHORT).auto.tfvars \
 		-out=$(TFPLAN)
  
- $(ENV_NAME).auto.tfvars:
+$(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
 
 trvs-collectd-vsphere.auto.tfvars:

--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -30,7 +30,7 @@ module "worker_production_org_1" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="60"
+export TRAVIS_WORKER_POOL_SIZE="35"
 export TRAVIS_WORKER_PPROF_PORT="7070"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-1-dc18"
@@ -50,7 +50,7 @@ module "worker_production_org_2" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="60"
+export TRAVIS_WORKER_POOL_SIZE="35"
 export TRAVIS_WORKER_PPROF_PORT="7071"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-2-dc18"
@@ -109,7 +109,7 @@ module "worker_production_com_1" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="55"
+export TRAVIS_WORKER_POOL_SIZE="30"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-1-dc18"
 EOF
@@ -129,7 +129,7 @@ module "worker_production_com_2" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="55"
+export TRAVIS_WORKER_POOL_SIZE="30"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-2-dc18"
 EOF

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -1,5 +1,4 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
-include $(shell git rev-parse --show-toplevel)/trvs.mk
 
 PROD_TF_VERSION := v0.9.11
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
@@ -34,8 +33,10 @@ CONFIG_FILES := \
 
 INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
 
+include $(shell git rev-parse --show-toplevel)/trvs.mk
+
 .PHONY: .config
-.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
+.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars trvs-collectd-vsphere.auto.tfvars
 
 $(CONFIG_FILES):
 	mkdir -p config
@@ -87,6 +88,17 @@ $(CONFIG_FILES):
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 
+.PHONY: plan
+plan: announce .config $(TRVS_TFVARS) $(TFSTATE)
+	$(TERRAFORM) plan -module-depth=-1 \
+		-var-file=$(ENV_NAME).auto.tfvars \
+		-var-file=trvs-collectd-vsphere.auto.tfvars \
+		-var-file=trvs-$(ENV_NAME).auto.tfvars \
+		-var-file=trvs-$(INFRA)-$(ENV_SHORT).auto.tfvars \
+		-out=$(TFPLAN)
+		
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs-collectd-vsphere.auto.tfvars
+
+trvs-collectd-vsphere.auto.tfvars:
+	trvs generate-config -f json collectd-vsphere common-$(INDEX) -o $@

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -95,4 +95,3 @@ $(TRVS_ENV_NAME_TFVARS):
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
 	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
-	

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -1,4 +1,5 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+include $(shell git rev-parse --show-toplevel)/trvs.mk
 
 PROD_TF_VERSION := v0.9.11
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
@@ -88,4 +89,4 @@ $(CONFIG_FILES):
 
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
+	trvs-collectd-vsphere.auto.tfvars

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -1,4 +1,5 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+include $(shell git rev-parse --show-toplevel)/trvs.mk
 
 PROD_TF_VERSION := v0.9.11
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
@@ -86,12 +87,6 @@ $(CONFIG_FILES):
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 
-$(TRVS_INFRA_ENV_TFVARS):
-	trvs generate-config -f json terraform-config $(INFRA)_$(ENV_SHORT) >$@
-
-$(TRVS_ENV_NAME_TFVARS):
-	trvs generate-config -f json terraform-config $(subst -,_,$(ENV_NAME)) >$@
-	
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
+	trvs-collectd-vsphere.auto.tfvars

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -95,3 +95,4 @@ $(TRVS_ENV_NAME_TFVARS):
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
 	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@
+	

--- a/macstadium-pod-2/Makefile
+++ b/macstadium-pod-2/Makefile
@@ -1,5 +1,4 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
-include $(shell git rev-parse --show-toplevel)/trvs.mk
 
 PROD_TF_VERSION := v0.9.11
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
@@ -87,6 +86,12 @@ $(CONFIG_FILES):
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 
+$(TRVS_INFRA_ENV_TFVARS):
+	trvs generate-config -f json terraform-config $(INFRA)_$(ENV_SHORT) >$@
+
+$(TRVS_ENV_NAME_TFVARS):
+	trvs generate-config -f json terraform-config $(subst -,_,$(ENV_NAME)) >$@
+	
 $(ENV_NAME).auto.tfvars:
 	$(TOP)/bin/generate-tfvars $@
-	trvs-collectd-vsphere.auto.tfvars
+	trvs generate-config -f hcl collectd-vsphere common-$(INDEX) >> $@

--- a/macstadium-pod-2/workers.tf
+++ b/macstadium-pod-2/workers.tf
@@ -30,7 +30,7 @@ module "worker_production_org_1" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="60"
+export TRAVIS_WORKER_POOL_SIZE="35"
 export TRAVIS_WORKER_PPROF_PORT="7070"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-1-dc18"
@@ -50,7 +50,7 @@ module "worker_production_org_2" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="60"
+export TRAVIS_WORKER_POOL_SIZE="35"
 export TRAVIS_WORKER_PPROF_PORT="7071"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-2-dc18"
@@ -109,7 +109,7 @@ module "worker_production_com_1" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="55"
+export TRAVIS_WORKER_POOL_SIZE="30"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-1-dc18"
 EOF
@@ -129,7 +129,7 @@ module "worker_production_com_2" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="55"
+export TRAVIS_WORKER_POOL_SIZE="30"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-2-dc18"
 EOF


### PR DESCRIPTION
We've hit bottlenecks in the SAN, which can't handle too many running
VMs at once without causing latenccy and requeue spikes. By lowering
worker pool sizes, we prevent this and keep efficient job throughput.

## What is the problem that this PR is trying to fix?

## What approach did you choose and why?

## How can you test this?
terraform plan 

## What feedback would you like, if any?
