### PR TITLE
Add make target for showing a unified diff version of a tfplan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
   global:
   - PATH="${HOME}/bin:${PATH}"
   - TMPDIR="${TMPDIR:-/tmp}"
-before_install: make deps
+before_install:
+- eval "$(gimme 1.9.4)"
+- make deps
 script:
 - make test
 - make assert-clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELLCHECK_URL := https://s3.amazonaws.com/travis-blue-public/binaries/ubuntu/14.04/x86_64/shellcheck-0.4.4.tar.bz2
 SHFMT_URL := mvdan.cc/sh/cmd/shfmt
+TFPLAN2JSON_URL := go-gist.appspot.com/meatballhat/d644c2f75dd98cba6638c38e7a9561a2/tfplan2json
 
 SHELL := bash
 
@@ -20,7 +21,7 @@ assert-clean:
 	$(GIT) diff --cached --exit-code
 
 .PHONY: deps
-deps: .ensure-terraforms .ensure-shellcheck .ensure-shfmt
+deps: .ensure-terraforms .ensure-shellcheck .ensure-shfmt .ensure-tfplan2json
 
 .PHONY: .ensure-terraforms
 .ensure-terraforms:
@@ -41,3 +42,7 @@ deps: .ensure-terraforms .ensure-shellcheck .ensure-shfmt
 .PHONY: .ensure-shfmt
 .ensure-shfmt:
 	$(GO) get -u "$(SHFMT_URL)"
+
+.PHONY: .ensure-tfplan2json
+.ensure-tfplan2json:
+	$(GO) get -u "$(TFPLAN2JSON_URL)"

--- a/bin/tfplandiff
+++ b/bin/tfplandiff
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+def main
+  tfplan = ARGV.first
+  fail 'Missing {tfplan} input as first argument' if tfplan.nil?
+
+  differ = ENV.fetch('TFPLANDIFF_DIFFER', 'diff')
+
+  require 'json'
+  require 'tmpdir'
+
+  tfplan_parsed = JSON.parse(`tfplan2json <#{tfplan}`)
+  target_module = tfplan_parsed.fetch('Diff').fetch('Modules').find do |mod|
+    !mod.fetch('Resources').empty?
+  end
+
+  target_module.fetch('Resources')
+    .reject { |n, _| n.start_with?('data.') }.each do |n, v|
+    $stdout.puts(gen_resource_diff(n, v, differ: differ))
+  end
+
+  0
+end
+
+def gen_resource_diff(resource_name, definition, differ: 'diff')
+  out = []
+
+  Dir.mktmpdir(%w[tfplandiff- -tmp]) do |tmpdir|
+    definition.fetch('Attributes').each do |attr_name, attr_def|
+      a_name = File.join(tmpdir, "a-#{attr_name}")
+      b_name = File.join(tmpdir, "b-#{attr_name}")
+      File.write(a_name, attr_def.fetch('Old') + "\n")
+      File.write(b_name, attr_def.fetch('New') + "\n")
+      diff_command = %W[
+        #{differ} -u
+          --label a/#{resource_name}/#{attr_name}
+          #{a_name}
+          --label b/#{resource_name}/#{attr_name}
+          #{b_name}
+      ]
+      out << `#{diff_command.join(' ')}`
+    end
+  end
+
+  out.join("\n")
+end
+
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -68,6 +68,10 @@ console: announce
 plan: announce .config $(TRVS_TFVARS) $(TFSTATE)
 	$(TERRAFORM) plan -module-depth=-1 -out=$(TFPLAN)
 
+.PHONY: plandiff
+plandiff: $(TFPLAN)
+	$(TOP)/bin/tfplandiff $^
+
 .PHONY: destroy
 destroy: announce .config $(TRVS_TFVARS) $(TFSTATE)
 	$(TERRAFORM) plan -module-depth=-1 -destroy -out=$(TFPLAN)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The default (only) output from `terraform plan` displays all strings as `"before" => "after"`, even if the values are _very big_, which means that figuring out what is going to change is generally a difficult task.

## What approach did you choose and why?

Add a `plandiff` target that is meant to be run _after_ `plan` to display the most recently output `*.tfplan` file in unified diff format.