### PR TITLE
Upgrade default terraform to v0.11.5

### DIFF
--- a/dns-production-0/Makefile
+++ b/dns-production-0/Makefile
@@ -4,7 +4,6 @@ INDEX := 0
 
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
 
 .PHONY: .config

--- a/gce-production-net-1/Makefile
+++ b/gce-production-net-1/Makefile
@@ -3,5 +3,4 @@ ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-2/Makefile
+++ b/gce-production-net-2/Makefile
@@ -3,5 +3,4 @@ ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-3/Makefile
+++ b/gce-production-net-3/Makefile
@@ -3,5 +3,4 @@ ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-4/Makefile
+++ b/gce-production-net-4/Makefile
@@ -3,5 +3,4 @@ ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-5/Makefile
+++ b/gce-production-net-5/Makefile
@@ -3,5 +3,4 @@ ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-staging-1/Makefile
+++ b/gce-staging-1/Makefile
@@ -5,5 +5,4 @@ AMQP_URL_VARNAME := RABBITMQ_BIGWIG_RX_URL
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-staging-net-1/Makefile
+++ b/gce-staging-net-1/Makefile
@@ -6,5 +6,4 @@ TRAVIS_BUILD_ORG_HOST := build-staging.travis-ci.org
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
-PROD_TF_VERSION := v0.11.2
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -16,7 +16,7 @@ TOP := $(shell git rev-parse --show-toplevel)
 TFWBZ2 := $(TOP)/assets/tfw.tar.bz2
 NATBZ2 := $(TOP)/assets/nat.tar.bz2
 
-PROD_TF_VERSION := v0.11.0
+PROD_TF_VERSION := v0.11.5
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
 TAR := tar
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The default value for `PROD_TF_VERSION` is `v0.11.0`, which was released in mid-November 2017, which is not a very long time ago, but is long enough ago that there have been bug fixes since then.  Additionally, all of the `gce-.*` directories have overrides to use `v0.11.2`, which is also not the latest, and is different than `v0.11.0` :confused: 

## What approach did you choose and why?

Switch the default value for `PROD_TF_VERSION` to `v0.11.5`, which was released on March 21, 2018 and remove the overrides in `gce-.*` directories so that we can live in a sparkly less-distant past together.

## How can you test this?

Migrating each graph dir to use `v0.11.5` can be done after this PR is merged, and if we hit any issues with compatibility, then instead possibly choose to pin the affected graph dirs to an earlier version.