### PR TITLE
Shift some com GCE worker load from 2 to 3

### DIFF
--- a/gce-production-2/instance-counts.auto.tfvars
+++ b/gce-production-2/instance-counts.auto.tfvars
@@ -1,4 +1,4 @@
 {
-  "worker_instance_count_com": 8,
+  "worker_instance_count_com": 4,
   "worker_instance_count_org": 4
 }

--- a/gce-production-3/instance-counts.auto.tfvars
+++ b/gce-production-3/instance-counts.auto.tfvars
@@ -1,4 +1,4 @@
 {
-  "worker_instance_count_com": 4,
+  "worker_instance_count_com": 8,
   "worker_instance_count_org": 4
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The workers in gce-production-2 are currently experiencing quota errors due to the lower-than-expected CPU quota of 2000.

## What approach did you choose and why?

Move com worker capacity from gce-production-2 to gce-production-3, where there is a CPU quota of 7500.