### PR TITLE
Remove us-central1-c from GCE job VM zones

### DIFF
--- a/gce-production-1/worker.env
+++ b/gce-production-1/worker.env
@@ -18,7 +18,11 @@ export TRAVIS_WORKER_GCE_RATE_LIMIT_TICK=2s
 export TRAVIS_WORKER_GCE_REGION=us-central1
 export TRAVIS_WORKER_GCE_SKIP_STOP_POLL=true
 export TRAVIS_WORKER_GCE_UPLOAD_RETRIES=300
-export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+# FIXME: add back us-central1-c when there are more resources available (?)
+# {
+# export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-f
+# }
 export TRAVIS_WORKER_POOL_SIZE=30
 export TRAVIS_WORKER_PPROF_PORT=6060
 export TRAVIS_WORKER_PROVIDER_NAME=gce

--- a/gce-production-2/worker.env
+++ b/gce-production-2/worker.env
@@ -18,7 +18,11 @@ export TRAVIS_WORKER_GCE_RATE_LIMIT_TICK=2s
 export TRAVIS_WORKER_GCE_REGION=us-central1
 export TRAVIS_WORKER_GCE_SKIP_STOP_POLL=true
 export TRAVIS_WORKER_GCE_UPLOAD_RETRIES=300
-export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+# FIXME: add back us-central1-c when there are more resources available (?)
+# {
+# export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-f
+# }
 export TRAVIS_WORKER_POOL_SIZE=30
 export TRAVIS_WORKER_PPROF_PORT=6060
 export TRAVIS_WORKER_PROVIDER_NAME=gce

--- a/gce-production-3/worker.env
+++ b/gce-production-3/worker.env
@@ -18,7 +18,11 @@ export TRAVIS_WORKER_GCE_RATE_LIMIT_TICK=2s
 export TRAVIS_WORKER_GCE_REGION=us-central1
 export TRAVIS_WORKER_GCE_SKIP_STOP_POLL=true
 export TRAVIS_WORKER_GCE_UPLOAD_RETRIES=300
-export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+# FIXME: add back us-central1-c when there are more resources available (?)
+# {
+# export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-f
+# }
 export TRAVIS_WORKER_POOL_SIZE=30
 export TRAVIS_WORKER_PPROF_PORT=6060
 export TRAVIS_WORKER_PROVIDER_NAME=gce

--- a/gce-production-4/worker.env
+++ b/gce-production-4/worker.env
@@ -18,7 +18,11 @@ export TRAVIS_WORKER_GCE_RATE_LIMIT_TICK=2s
 export TRAVIS_WORKER_GCE_REGION=us-central1
 export TRAVIS_WORKER_GCE_SKIP_STOP_POLL=true
 export TRAVIS_WORKER_GCE_UPLOAD_RETRIES=300
-export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+# FIXME: add back us-central1-c when there are more resources available (?)
+# {
+# export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-f
+# }
 export TRAVIS_WORKER_POOL_SIZE=30
 export TRAVIS_WORKER_PPROF_PORT=6060
 export TRAVIS_WORKER_PROVIDER_NAME=gce

--- a/gce-production-5/worker.env
+++ b/gce-production-5/worker.env
@@ -18,7 +18,11 @@ export TRAVIS_WORKER_GCE_RATE_LIMIT_TICK=2s
 export TRAVIS_WORKER_GCE_REGION=us-central1
 export TRAVIS_WORKER_GCE_SKIP_STOP_POLL=true
 export TRAVIS_WORKER_GCE_UPLOAD_RETRIES=300
-export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+# FIXME: add back us-central1-c when there are more resources available (?)
+# {
+# export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-c,us-central1-f
+export TRAVIS_WORKER_GCE_ZONES=us-central1-a,us-central1-b,us-central1-f
+# }
 export TRAVIS_WORKER_PPROF_PORT=6060
 export TRAVIS_WORKER_PROVIDER_NAME=gce
 export TRAVIS_WORKER_QUEUE_NAME=builds.gce


### PR DESCRIPTION
as we are currently receiving a ZONE_RESOURCE_POOL_EXHAUSTED error from the GCE API