### PR TITLE
Add a check for what branch is being terraformed from

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ assert-clean:
 	$(GIT) diff --cached --exit-code
 
 .PHONY: deps
-deps: .ensure-terraforms .ensure-shellcheck .ensure-shfmt .ensure-tfplan2json
+deps: .ensure-git .ensure-terraforms .ensure-shellcheck .ensure-shfmt .ensure-tfplan2json
 
 .PHONY: .ensure-terraforms
 .ensure-terraforms:
@@ -46,3 +46,17 @@ deps: .ensure-terraforms .ensure-shellcheck .ensure-shfmt .ensure-tfplan2json
 .PHONY: .ensure-tfplan2json
 .ensure-tfplan2json:
 	$(GO) get -u "$(TFPLAN2JSON_URL)"
+
+.PHONY: .ensure-git
+.ensure-git:
+	if [[ "$$(git rev-parse --abbrev-ref HEAD)" != "master" ]]; then \
+		echo "$$(tput setaf 1)WARN: You are about to deploy from a branch that is not master!$$(tput sgr 0)" ;\
+		echo "If you are $$(tput setaf 1)SUPER DUPER SURE$$(tput sgr 0) you wish to do this, type yes:" ;\
+		read answer; \
+		if [[ "$$answer" == "yes" ]]; then \
+			echo "Okay have fun!"; \
+		else \
+			echo "That's a good call too, better luck next time." ; \
+			exit 1; \
+		fi ;\
+	fi


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
We would like to avoid accidentally deploying terraform from non-master branches, as this could lead to changes in the production terraform state without a clear git/commit trail of _how_ they happened.

## What approach did you choose and why?
I added a branch check to the top level of the makefile, with user interaction/warning. It seems sensible to have *some* way of overriding the master-only rule in dire circumstances, but we want to make sure people are aware that they are doing that.

## How can you test this?
I used terminal, it was super effective!
![screen shot 2018-04-09 at 17 12 25](https://user-images.githubusercontent.com/397565/38523572-f23ec9a2-3c19-11e8-8aa0-56bd43c849bd.png)
![screen shot 2018-04-09 at 17 12 43](https://user-images.githubusercontent.com/397565/38523578-f84d07d2-3c19-11e8-9d6a-0fd04b453486.png)

## What feedback would you like, if any?
Does my bash look reasonable? Does this seem like an ok way of implementing this check?