### PR TITLE
A few minor tweaks to the .ensure-git target

### DIFF
--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -111,17 +111,17 @@ check:
 
 .PHONY: .ensure-git
 .ensure-git:
-  if [[ "$$(git rev-parse --abbrev-ref HEAD)" != "master" ]]; then \
-    echo "$$(tput setaf 1)WARN: You are about to deploy from a branch that is not master!$$(tput sgr 0)" ;\
-    echo "If you are $$(tput setaf 1)SUPER DUPER SURE$$(tput sgr 0) you wish to do this, type yes:" ;\
-    read answer; \
-    if [[ "$$answer" == "yes" ]]; then \
-      echo "Okay have fun!"; \
-    else \
-      echo "That's a good call too, better luck next time." ; \
-      exit 1; \
-    fi ;\
-  fi
+	@if [[ "$$(git rev-parse --abbrev-ref HEAD)" != "master" ]]; then \
+		echo "$$(tput setaf 1)WARN: You are about to deploy from a branch that is not master!$$(tput sgr 0)"; \
+		echo -n "If you are $$(tput setaf 1)SUPER DUPER SURE$$(tput sgr 0) you wish to do this, type yes: "; \
+		read -r answer; \
+		if [[ "$$answer" == "yes" ]]; then \
+			echo "Okay have fun!"; \
+		else \
+			echo "That's a good call too, better luck next time."; \
+			exit 1; \
+		fi; \
+	fi
 
 config/.written:
 	$(TOP)/bin/write-config-files \


### PR DESCRIPTION
including making sure leading space is hard tabs (which were maybe lost
via a commit hook or git config somewhere?), the shell snippet is not
echoed, and the answer is requested on same line.