### PR TITLE
Replace some spaces with tabs in terraform-common.mk

### DIFF
--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -111,17 +111,17 @@ check:
 
 .PHONY: .ensure-git
 .ensure-git:
-  if [[ "$$(git rev-parse --abbrev-ref HEAD)" != "master" ]]; then \
-    echo "$$(tput setaf 1)WARN: You are about to deploy from a branch that is not master!$$(tput sgr 0)" ;\
-    echo "If you are $$(tput setaf 1)SUPER DUPER SURE$$(tput sgr 0) you wish to do this, type yes:" ;\
-    read answer; \
-    if [[ "$$answer" == "yes" ]]; then \
-      echo "Okay have fun!"; \
-    else \
-      echo "That's a good call too, better luck next time." ; \
-      exit 1; \
-    fi ;\
-  fi
+	if [[ "$$(git rev-parse --abbrev-ref HEAD)" != "master" ]]; then \
+		echo "$$(tput setaf 1)WARN: You are about to deploy from a branch that is not master!$$(tput sgr 0)" ;\
+ 		echo "If you are $$(tput setaf 1)SUPER DUPER SURE$$(tput sgr 0) you wish to do this, type yes:" ;\
+ 		read answer; \
+		if [[ "$$answer" == "yes" ]]; then \
+			echo "Okay have fun!"; \
+		else \
+			echo "That's a good call too, better luck next time." ; \
+			exit 1; \
+		fi ;\
+	fi
 
 config/.written:
 	$(TOP)/bin/write-config-files \


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Running `make plan` failed:
```
$ make plan
/home/aj/git/travis/terraform-config/terraform-common.mk:114: *** missing separator.  Stop.
```

## What approach did you choose and why?

It seems `make` did not appreciate having spaces instead of tabs?

## How can you test this?

Run `make plan` in `aws-staging-1`.