### PR TITLE
Remove now-unnecessary TERRAFORM overrides

### DIFF
--- a/dns-production-0/Makefile
+++ b/dns-production-0/Makefile
@@ -4,8 +4,6 @@ INDEX := 0
 
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
-
 .PHONY: .config
 .config: $(ENV_NAME).auto.tfvars
 

--- a/gce-production-net-1/Makefile
+++ b/gce-production-net-1/Makefile
@@ -2,5 +2,3 @@ AMQP_URL_VARNAME := CLOUDAMQP_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-2/Makefile
+++ b/gce-production-net-2/Makefile
@@ -2,5 +2,3 @@ AMQP_URL_VARNAME := CLOUDAMQP_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-3/Makefile
+++ b/gce-production-net-3/Makefile
@@ -2,5 +2,3 @@ AMQP_URL_VARNAME := CLOUDAMQP_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-4/Makefile
+++ b/gce-production-net-4/Makefile
@@ -2,5 +2,3 @@ AMQP_URL_VARNAME := CLOUDAMQP_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-production-net-5/Makefile
+++ b/gce-production-net-5/Makefile
@@ -2,5 +2,3 @@ AMQP_URL_VARNAME := CLOUDAMQP_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)

--- a/gce-staging-net-1/Makefile
+++ b/gce-staging-net-1/Makefile
@@ -5,5 +5,3 @@ TRAVIS_BUILD_COM_HOST := build-staging.travis-ci.com
 TRAVIS_BUILD_ORG_HOST := build-staging.travis-ci.org
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The override definitions of `TERRAFORM` are no longer needed in projects other than `macstadium-*`.

## What approach did you choose and why?

Remove the overrides!