### PR TITLE
Stop using high CPU check on Packet

### DIFF
--- a/modules/packet_worker/cloud-config.yml.tpl
+++ b/modules/packet_worker/cloud-config.yml.tpl
@@ -42,16 +42,6 @@ write_files:
   owner: 'root:root'
   path: /etc/cron.d/travis-worker-clean-up-containers
   permissions: '0644'
-- content: '${base64encode(file("${assets}/travis-worker/high-cpu-check.bash"))}'
-  encoding: b64
-  owner: 'root:root'
-  path: /var/tmp/travis-run.d/high-cpu-check
-  permissions: '0750'
-- content: '${base64encode(file("${assets}/travis-worker/high-cpu-check.crontab"))}'
-  encoding: b64
-  owner: 'root:root'
-  path: /etc/cron.d/travis-worker-high-cpu-check
-  permissions: '0644'
 - content: '${base64encode(syslog_address)}'
   encoding: b64
   path: /var/tmp/travis-run.d/syslog-address


### PR DESCRIPTION
as the current implementation leaves around many detach `docker stats`
and `docker inspect` processes.