### PR TITLE
Increase inotify max instances for docker workers

### DIFF
--- a/modules/aws_asg/cloud-init.bash
+++ b/modules/aws_asg/cloud-init.bash
@@ -93,7 +93,6 @@ __set_max_inotify_instances() {
   local poolsize inotify_max
   poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
   inotify_max="$((8192 * ${poolsize:-15}))"
-  echo "$inotify_max" >/proc/sys/fs/inotify/max_user_instances
   sysctl -w fs.inotify.max_user_instances="$inotify_max"
 }
 

--- a/modules/aws_asg/cloud-init.bash
+++ b/modules/aws_asg/cloud-init.bash
@@ -92,8 +92,8 @@ __set_aio_max_nr() {
 __set_max_inotify_instances() {
   local poolsize inotify_max
   poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
-  inotify_max="$(( 8192 * ${poolsize:-15} ))"
-  echo "$inotify_max" > /proc/sys/fs/inotify/max_user_instances
+  inotify_max="$((8192 * ${poolsize:-15}))"
+  echo "$inotify_max" >/proc/sys/fs/inotify/max_user_instances
   sysctl -w fs.inotify.max_user_instances="$inotify_max"
 }
 

--- a/modules/aws_asg/cloud-init.bash
+++ b/modules/aws_asg/cloud-init.bash
@@ -90,8 +90,9 @@ __set_aio_max_nr() {
 }
 
 __set_max_inotify_instances() {
-  local poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
-  local inotify_max="$(( 8192 * ${poolsize:-15} ))"
+  local poolsize inotify_max
+  poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
+  inotify_max="$(( 8192 * ${poolsize:-15} ))"
   echo "$inotify_max" > /proc/sys/fs/inotify/max_user_instances
   sysctl -w fs.inotify.max_user_instances="$inotify_max"
 }

--- a/modules/packet_worker/cloud-init.bash
+++ b/modules/packet_worker/cloud-init.bash
@@ -77,6 +77,12 @@ __setup_travis_user() {
 __setup_sysctl() {
   echo 1048576 >/proc/sys/fs/aio-max-nr
   sysctl -w fs.aio-max-nr=1048576
+
+  local poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
+  local inotify_max="$(( 8192 * ${poolsize:-15} ))"
+  echo "$inotify_max" > /proc/sys/fs/inotify/max_user_instances
+  sysctl -w fs.inotify.max_user_instances="$inotify_max"
+
 }
 
 __setup_networking() {

--- a/modules/packet_worker/cloud-init.bash
+++ b/modules/packet_worker/cloud-init.bash
@@ -80,8 +80,8 @@ __setup_sysctl() {
 
   local poolsize inotify_max
   poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
-  inotify_max="$(( 8192 * ${poolsize:-15} ))"
-  echo "$inotify_max" > /proc/sys/fs/inotify/max_user_instances
+  inotify_max="$((8192 * ${poolsize:-15}))"
+  echo "$inotify_max" >/proc/sys/fs/inotify/max_user_instances
   sysctl -w fs.inotify.max_user_instances="$inotify_max"
 
 }

--- a/modules/packet_worker/cloud-init.bash
+++ b/modules/packet_worker/cloud-init.bash
@@ -78,8 +78,9 @@ __setup_sysctl() {
   echo 1048576 >/proc/sys/fs/aio-max-nr
   sysctl -w fs.aio-max-nr=1048576
 
-  local poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
-  local inotify_max="$(( 8192 * ${poolsize:-15} ))"
+  local poolsize inotify_max
+  poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
+  inotify_max="$(( 8192 * ${poolsize:-15} ))"
   echo "$inotify_max" > /proc/sys/fs/inotify/max_user_instances
   sysctl -w fs.inotify.max_user_instances="$inotify_max"
 

--- a/modules/packet_worker/cloud-init.bash
+++ b/modules/packet_worker/cloud-init.bash
@@ -81,7 +81,6 @@ __setup_sysctl() {
   local poolsize inotify_max
   poolsize="$(awk -F= '/TRAVIS_WORKER_POOL_SIZE/{print $2; exit}' /etc/default/travis-worker 2>/dev/null || true)"
   inotify_max="$((8192 * ${poolsize:-15}))"
-  echo "$inotify_max" >/proc/sys/fs/inotify/max_user_instances
   sysctl -w fs.inotify.max_user_instances="$inotify_max"
 
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Users occasionally run into not being able to create more file
listeners, as this is a shared resource on the docker host. This
fix sets fs.inotify.max_user_instances to WORKER_POOL_SIZE *
the default value.

Hopes are that these errors would plummet:
https://papertrailapp.com/groups/3719173/events?q=inotify_add_watch

## What approach did you choose and why?
Increase the max at image bootstrap time

## How can you test this?
Look at `/proc/sys/fs/inotify/max_user_instances`

## What feedback would you like, if any?
Any.