### PR TITLE
Set bash SHELL for all

### DIFF
--- a/aws.mk
+++ b/aws.mk
@@ -1,5 +1,3 @@
-SHELL := bash
-
 TOP := $(shell git rev-parse --show-toplevel)
 
 include $(TOP)/terraform-common.mk

--- a/packet.mk
+++ b/packet.mk
@@ -1,5 +1,3 @@
-SHELL := bash
-
 TOP := $(shell git rev-parse --show-toplevel)
 
 include $(TOP)/terraform-common.mk

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -1,3 +1,4 @@
+SHELL := bash
 ENV_NAME := $(notdir $(shell cd $(PWD) && pwd))
 ENV_SHORT ?= $(word 2,$(subst -, ,$(ENV_NAME)))
 INFRA ?= $(word 1,$(subst -, ,$(ENV_NAME)))


### PR DESCRIPTION
This is a practical change for macstadium and GCE.

## What is the problem that this PR is trying to fix?
`/bin/sh: 1: [[: not found`

## What approach did you choose and why?
Define SHELL to be bash in terraform-common.mk, rather than in each project's individual mk file.

## How can you test this?
`terraform apply` a non-master branch :grimacing: 

## What feedback would you like, if any?
