### PR TITLE
Cha pool size 2core vms

### DIFF
--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -31,7 +31,7 @@ module "worker_production_org_1" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="40"
+export TRAVIS_WORKER_POOL_SIZE="60"
 export TRAVIS_WORKER_PPROF_PORT="7070"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-1-dc18"
@@ -51,7 +51,7 @@ module "worker_production_org_2" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="40"
+export TRAVIS_WORKER_POOL_SIZE="60"
 export TRAVIS_WORKER_PPROF_PORT="7071"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-2-dc18"
@@ -110,7 +110,7 @@ module "worker_production_com_1" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="20"
+export TRAVIS_WORKER_POOL_SIZE="40"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-1-dc18"
 EOF
@@ -130,7 +130,7 @@ module "worker_production_com_2" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="20"
+export TRAVIS_WORKER_POOL_SIZE="40"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-2-dc18"
 EOF

--- a/macstadium-pod-2/workers.tf
+++ b/macstadium-pod-2/workers.tf
@@ -30,7 +30,7 @@ module "worker_production_org_1" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="35"
+export TRAVIS_WORKER_POOL_SIZE="60"
 export TRAVIS_WORKER_PPROF_PORT="7070"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-1-dc18"
@@ -50,7 +50,7 @@ module "worker_production_org_2" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="35"
+export TRAVIS_WORKER_POOL_SIZE="60"
 export TRAVIS_WORKER_PPROF_PORT="7071"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-2-dc18"
@@ -109,7 +109,7 @@ module "worker_production_com_1" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="30"
+export TRAVIS_WORKER_POOL_SIZE="40"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-1-dc18"
 EOF
@@ -129,7 +129,7 @@ module "worker_production_com_2" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="30"
+export TRAVIS_WORKER_POOL_SIZE="40"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-2-dc18"
 EOF


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We are re-adjusting the worker pool sizes based on the build VM sizing and availability for 2 core, 4 GB RAM 

## What approach did you choose and why?
[Worker pool size math](https://travisci.slack.com/archives/C45D4L2QP/p1525108181000307) based on available macpro compute divided by build vms per macpro, in both vCenter instances. 

## How can you test this?
The `terraform plan` output shows the appropriate changes, but  rather than `terraform apply` these changes, I sshed into the hosts and made the changes on the configs and restarted.  This PR is simply to merge for documentation / posterity / source of truth.  
 
NB: As we move to refactor into smaller graph directories, I won't make it a habit of doing it this way. 

## What feedback would you like, if any?
