### PR TITLE
Add a pupcycler to Packet staging

### DIFF
--- a/bin/heroku-wait-deploy-scale
+++ b/bin/heroku-wait-deploy-scale
@@ -23,12 +23,12 @@ main() {
 
   local repo_slug="${1}"
   local heroku_app="${2}"
-  local ps_scale="${3}"
+  local ps_scale=("${3//,/ }")
   local version="${4:-master}"
 
   __heroku_wait "${heroku_app}"
   __heroku_deploy "${repo_slug}" "${heroku_app}" "${version}"
-  __heroku_scale "${heroku_app}" "${ps_scale}"
+  __heroku_scale "${heroku_app}" "${ps_scale[@]}"
 }
 
 __heroku_wait() {
@@ -82,17 +82,19 @@ __make_deploy_request() {
 
 __heroku_scale() {
   local heroku_app="${1}"
-  local ps_scale="${2}"
-  local formation_type="${ps_scale%%=*}"
-  local formation_scale="${ps_scale##*=}"
-  local formation_scale_qty="${formation_scale%%:*}"
-  local formation_scale_size="${formation_scale##*:}"
+  shift
+  for ps_scale in "${@}"; do
+    local formation_type="${ps_scale%%=*}"
+    local formation_scale="${ps_scale##*=}"
+    local formation_scale_qty="${formation_scale%%:*}"
+    local formation_scale_size="${formation_scale##*:}"
 
-  __heroku_curl -s -X PATCH -d "{
-      \"quantity\": ${formation_scale_qty},
-      \"size\": \"${formation_scale_size}\"
-    }" \
-    "https://api.heroku.com/apps/${heroku_app}/formation/${formation_type}"
+    __heroku_curl -s -X PATCH -d "{
+        \"quantity\": ${formation_scale_qty},
+        \"size\": \"${formation_scale_size}\"
+      }" \
+      "https://api.heroku.com/apps/${heroku_app}/formation/${formation_type}"
+  done
 }
 
 __heroku_curl() {

--- a/modules/packet_network/main.tf
+++ b/modules/packet_network/main.tf
@@ -103,6 +103,7 @@ resource "packet_device" "nat" {
   plan             = "${var.nat_server_plan}"
   project_id       = "${var.project_id}"
   user_data        = "${element(data.template_file.nat_user_data.*.rendered, count.index)}"
+  tags             = ["nat", "${var.env}"]
 
   lifecycle {
     ignore_changes = ["root_password", "user_data"]

--- a/modules/packet_worker/dynamic-config.yml.tpl
+++ b/modules/packet_worker/dynamic-config.yml.tpl
@@ -5,12 +5,6 @@ write_files:
 - content: '${base64encode(github_users_env)}'
   encoding: b64
   path: /etc/default/github-users
-- content: '${base64encode(worker_config)}'
-  encoding: b64
-  path: /etc/default/travis-worker
-- content: '${base64encode(cloud_init_env)}'
-  encoding: b64
-  path: /etc/default/travis-worker-cloud-init
 - content: '${base64encode(file("${assets}/rsyslog/rsyslog.conf"))}'
   encoding: b64
   path: /etc/rsyslog.conf
@@ -40,6 +34,14 @@ write_files:
   encoding: b64
   path: /var/tmp/travis-run.d/travis-worker-prestart-hook
   permissions: '0750'
+- content: '${base64encode(file("${here}/start-hook.bash"))}'
+  encoding: b64
+  path: /var/tmp/travis-run.d/travis-worker-start-hook
+  permissions: '0750'
+- content: '${base64encode(file("${here}/stop-hook.bash"))}'
+  encoding: b64
+  path: /var/tmp/travis-run.d/travis-worker-stop-hook
+  permissions: '0750'
 - content: '${base64encode(file("${assets}/travis-worker/travis-worker.service"))}'
   encoding: b64
   path: /var/tmp/travis-worker.service
@@ -47,7 +49,17 @@ write_files:
   encoding: b64
   permissions: '0755'
   path: /var/tmp/travis-worker-dynamic-config.bash
+- content: '${base64encode(worker_config)}'
+  encoding: b64
+  path: /var/tmp/travis-worker.env.tmpl
+- content: '${base64encode(cloud_init_env)}'
+  encoding: b64
+  path: /var/tmp/travis-worker-cloud-init.env.tmpl
 - content: '${base64encode(file("${assets}/bits/travis-packet-privnet-setup.bash"))}'
   encoding: b64
   permissions: '0755'
   path: /var/lib/cloud/scripts/per-boot/00-travis-packet-privnet-setup
+- content: '${base64encode(file("${assets}/bits/ensure-tfw.bash"))}'
+  encoding: b64
+  permissions: '0755'
+  path: /var/lib/cloud/scripts/per-boot/00-ensure-tfw

--- a/modules/packet_worker/main.tf
+++ b/modules/packet_worker/main.tf
@@ -20,6 +20,8 @@ variable "nat_public_ips" {
 }
 
 variable "project_id" {}
+variable "pupcycler_auth_token" {}
+variable "pupcycler_url" {}
 variable "server_count" {}
 
 variable "server_plan" {
@@ -52,6 +54,8 @@ data "tls_public_key" "terraform" {
 
 data "template_file" "cloud_init_env" {
   template = <<EOF
+export PUPCYCLER_AUTH_TOKEN="${var.pupcycler_auth_token}"
+export PUPCYCLER_URL="${var.pupcycler_url}"
 export TRAVIS_WORKER_DOCKER_IMAGE_ANDROID="${var.worker_docker_image_android}"
 export TRAVIS_WORKER_DOCKER_IMAGE_DEFAULT="${var.worker_docker_image_default}"
 export TRAVIS_WORKER_DOCKER_IMAGE_ERLANG="${var.worker_docker_image_erlang}"
@@ -64,6 +68,8 @@ export TRAVIS_WORKER_DOCKER_IMAGE_PHP="${var.worker_docker_image_php}"
 export TRAVIS_WORKER_DOCKER_IMAGE_PYTHON="${var.worker_docker_image_python}"
 export TRAVIS_WORKER_DOCKER_IMAGE_RUBY="${var.worker_docker_image_ruby}"
 export TRAVIS_WORKER_PRESTART_HOOK="/var/tmp/travis-run.d/travis-worker-prestart-hook"
+export TRAVIS_WORKER_START_HOOK="/var/tmp/travis-run.d/travis-worker-start-hook"
+export TRAVIS_WORKER_STOP_HOOK="/var/tmp/travis-run.d/travis-worker-stop-hook"
 export TRAVIS_WORKER_SELF_IMAGE="${var.worker_docker_self_image}"
 EOF
 }
@@ -129,6 +135,7 @@ resource "packet_device" "worker" {
   plan             = "${var.server_plan}"
   project_id       = "${var.project_id}"
   user_data        = "${element(data.template_file.user_data.*.rendered, count.index)}"
+  tags             = ["worker", "${var.site}", "${var.env}"]
 
   lifecycle {
     ignore_changes = ["root_password", "user_data"]

--- a/modules/packet_worker/start-hook.bash
+++ b/modules/packet_worker/start-hook.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# vim:filetype=sh
+set -o pipefail
+set -o errexit
+
+main() {
+  : "${RUNDIR:=/var/tmp/travis-run.d}"
+
+  local pupcycler_url pupcycler_auth_token instance_id
+  pupcycler_url="$(cat "${RUNDIR}/pupcycler-url")"
+  pupcycler_auth_token="$(cat "${RUNDIR}/pupcycler-auth-token")"
+  instance_id="$(cat "${RUNDIR}/instance-id-full")"
+
+  curl \
+    -f \
+    -X POST \
+    -H "Authorization: token ${pupcycler_auth_token}" \
+    "${pupcycler_url}/startups/${instance_id}"
+}
+
+main "$@"

--- a/modules/packet_worker/stop-hook.bash
+++ b/modules/packet_worker/stop-hook.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# vim:filetype=sh
+set -o pipefail
+set -o errexit
+
+main() {
+  : "${RUNDIR:=/var/tmp/travis-run.d}"
+
+  local pupcycler_url pupcycler_auth_token instance_id post_stop_sleep
+  pupcycler_url="$(cat "${RUNDIR}/pupcycler-url")"
+  instance_id="$(cat "${RUNDIR}/instance-id-full")"
+  pupcycler_auth_token="$(cat "${RUNDIR}/pupcycler-auth-token")"
+  post_stop_sleep="$(cat "${RUNDIR}/post-stop-sleep" 2>/dev/null || echo 300)"
+
+  curl \
+    -f \
+    -X POST \
+    -H "Authorization: token ${pupcycler_auth_token}" \
+    "${pupcycler_url}/shutdowns/${instance_id}"
+
+  sleep "${post_stop_sleep}"
+}
+
+main "$@"

--- a/modules/pupcycler/main.tf
+++ b/modules/pupcycler/main.tf
@@ -1,0 +1,69 @@
+variable "auth_token" {}
+variable "env" {}
+variable "heroku_org" {}
+variable "index" {}
+variable "packet_auth_token" {}
+variable "packet_project_id" {}
+
+variable "redis_plan" {
+  default = "premium-0"
+}
+
+variable "scale" {
+  type    = "list"
+  default = ["web=1:Standard-1X", "worker=1:Standard-1X"]
+}
+
+variable "syslog_address" {}
+
+variable "version" {
+  default = "master"
+}
+
+resource "heroku_app" "pupcycler" {
+  name   = "pupcycler-${var.env}-${var.index}"
+  region = "us"
+
+  organization {
+    name = "${var.heroku_org}"
+  }
+
+  config_vars {
+    PUPCYCLER_AUTH_TOKENS       = "${var.auth_token}"
+    PUPCYCLER_PACKET_AUTH_TOKEN = "${var.packet_auth_token}"
+    PUPCYCLER_PACKET_PROJECT_ID = "${var.packet_project_id}"
+  }
+}
+
+resource "heroku_drain" "pupcycler_drain" {
+  app = "${heroku_app.pupcycler.name}"
+  url = "syslog+tls://${var.syslog_address}"
+}
+
+resource "heroku_addon" "pupcycler_redis" {
+  app  = "${heroku_app.pupcycler.name}"
+  plan = "heroku-redis:${var.redis_plan}"
+}
+
+resource "null_resource" "pupcycler" {
+  triggers {
+    config_signature = "${sha256(join(",", values(heroku_app.pupcycler.config_vars.0)))}"
+    heroku_id        = "${heroku_app.pupcycler.id}"
+    scale            = "${join(",", var.scale)}"
+    version          = "${var.version}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+exec ${path.module}/../../bin/heroku-wait-deploy-scale \
+  travis-ci/pupcycler \
+  ${heroku_app.pupcycler.id} \
+  ${join(",", var.scale)} \
+  ${var.version}
+EOF
+  }
+}
+
+output "web_url" {
+  value = "${heroku_app.pupcycler.web_url}"
+}

--- a/packet-staging-1/main.tf
+++ b/packet-staging-1/main.tf
@@ -121,6 +121,7 @@ module "packet_workers_com" {
   worker_docker_image_php     = "${var.latest_docker_image_garnet}"
   worker_docker_image_python  = "${var.latest_docker_image_garnet}"
   worker_docker_image_ruby    = "${var.latest_docker_image_garnet}"
+  worker_docker_self_image    = "${var.latest_docker_image_worker}"
 }
 
 module "packet_workers_org" {

--- a/packet-staging-1/main.tf
+++ b/packet-staging-1/main.tf
@@ -13,7 +13,9 @@ variable "latest_docker_image_garnet" {}
 variable "latest_docker_image_worker" {}
 variable "librato_email" {}
 variable "librato_token" {}
-variable "project_id" {}
+variable "packet_auth_token" {}
+variable "packet_heroku_org" {}
+variable "packet_project_id" {}
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
@@ -29,6 +31,7 @@ terraform {
 
 provider "packet" {}
 provider "aws" {}
+provider "heroku" {}
 
 data "terraform_remote_state" "vpc" {
   backend = "s3"
@@ -41,6 +44,22 @@ data "terraform_remote_state" "vpc" {
   }
 }
 
+resource "random_id" "pupcycler_auth" {
+  byte_length = 16
+}
+
+module "pupcycler" {
+  source = "../modules/pupcycler"
+
+  auth_token        = "${random_id.pupcycler_auth.hex}"
+  env               = "${var.env}"
+  heroku_org        = "${var.packet_heroku_org}"
+  index             = "${var.index}"
+  packet_project_id = "${var.packet_project_id}"
+  packet_auth_token = "${var.packet_auth_token}"
+  syslog_address    = "${var.syslog_address_com}"
+}
+
 data "template_file" "worker_config_com" {
   template = <<EOF
 ### config/worker-com-local.env
@@ -50,6 +69,8 @@ ${file("${path.module}/config/worker-com.env")}
 ### worker.env
 ${file("${path.module}/worker.env")}
 
+export TRAVIS_WORKER_HEARTBEAT_URL="${replace(module.pupcycler.web_url, "/\\/$/", "")}/heartbeats/___INSTANCE_ID_FULL___"
+export TRAVIS_WORKER_HEARTBEAT_URL_AUTH_TOKEN="${random_id.pupcycler_auth.hex}"
 export TRAVIS_WORKER_TRAVIS_SITE=com
 EOF
 }
@@ -63,6 +84,8 @@ ${file("${path.module}/config/worker-org.env")}
 ### worker.env
 ${file("${path.module}/worker.env")}
 
+export TRAVIS_WORKER_HEARTBEAT_URL="${replace(module.pupcycler.web_url, "/\\/$/", "")}/heartbeats/___INSTANCE_ID_FULL___"
+export TRAVIS_WORKER_HEARTBEAT_URL_AUTH_TOKEN="${random_id.pupcycler_auth.hex}"
 export TRAVIS_WORKER_TRAVIS_SITE=org
 EOF
 }
@@ -79,7 +102,9 @@ module "packet_workers_com" {
   librato_token               = "${var.librato_token}"
   nat_ips                     = ["${data.terraform_remote_state.vpc.nat_ips}"]
   nat_public_ips              = ["${data.terraform_remote_state.vpc.nat_public_ips}"]
-  project_id                  = "${var.project_id}"
+  project_id                  = "${var.packet_project_id}"
+  pupcycler_auth_token        = "${random_id.pupcycler_auth.hex}"
+  pupcycler_url               = "${replace(module.pupcycler.web_url, "/\\/$/", "")}"
   server_count                = 1
   site                        = "com"
   syslog_address              = "${var.syslog_address_com}"
@@ -110,7 +135,9 @@ module "packet_workers_org" {
   librato_token               = "${var.librato_token}"
   nat_ips                     = ["${data.terraform_remote_state.vpc.nat_ips}"]
   nat_public_ips              = ["${data.terraform_remote_state.vpc.nat_public_ips}"]
-  project_id                  = "${var.project_id}"
+  project_id                  = "${var.packet_project_id}"
+  pupcycler_auth_token        = "${random_id.pupcycler_auth.hex}"
+  pupcycler_url               = "${replace(module.pupcycler.web_url, "/\\/$/", "")}"
   server_count                = 1
   site                        = "org"
   syslog_address              = "${var.syslog_address_org}"

--- a/packet-staging-net-1/main.tf
+++ b/packet-staging-net-1/main.tf
@@ -14,7 +14,7 @@ variable "index" {
 
 variable "librato_email" {}
 variable "librato_token" {}
-variable "project_id" {}
+variable "packet_project_id" {}
 variable "syslog_address_com" {}
 
 variable "travisci_net_external_zone_id" {
@@ -46,7 +46,7 @@ module "packet_network_ewr1" {
   index               = "${var.index}"
   librato_email       = "${var.librato_email}"
   librato_token       = "${var.librato_token}"
-  project_id          = "${var.project_id}"
+  project_id          = "${var.packet_project_id}"
   syslog_address      = "${var.syslog_address_com}"
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Worker servers in `packet-staging-1` can sometimes get into an unresponsive state where a reboot can be the cleanest way to get the server back into service.  This is why pupcycler exists, but it hasn't yet been integrated with `packet-staging-1`.

## What approach did you choose and why?

Add pupcycler integration!

## How can you test this?

- [x] works correctly (enough) in staging