### PR TITLE
Use trvs to make redis connection

### DIFF
--- a/bin/nat-conntracker-configure
+++ b/bin/nat-conntracker-configure
@@ -41,44 +41,26 @@ def main
     ) { |v| options[:heroku_api_key] = v.strip }
   end.parse!
 
-  conn = heroku_conn(options[:heroku_api_hostname])
-  req = Net::HTTP::Get.new("/apps/#{options[:app]}/config-vars")
-  req['Authorization'] = "Bearer #{options[:heroku_api_key]}"
-  req['Accept'] = 'application/vnd.heroku+json; version=3'
-  response = conn.request(req)
-  if Integer(response.code) > 299
-    fail "could not fetch vars for #{options[:app]}"
-  end
-
   expand_private!(options[:dst_ignore])
   expand_private!(options[:src_ignore])
 
-  redis_url = JSON.parse(response.body).fetch('REDIS_URL')
-
   unless Array(options[:dst_ignore]).empty?
     dst_command = %W[
-      redis-cli -u #{redis_url} SADD nat-conntracker:dst-ignore
+      trvs redis-cli #{options[:app]} REDIS_URL SADD nat-conntracker:dst-ignore
     ] + Array(options[:dst_ignore])
-    $stderr.puts("---> #{dst_command.join(' ')}".gsub(redis_url, '[REDACTED]'))
+    $stderr.puts("---> #{dst_command.join(' ')}")
     system(*dst_command)
   end
 
   unless Array(options[:src_ignore]).empty?
     src_command = %W[
-      redis-cli -u #{redis_url} SADD nat-conntracker:src-ignore
+      trvs redis-cli #{options[:app]} REDIS_URL SADD nat-conntracker:src-ignore
     ] + Array(options[:src_ignore])
-    $stderr.puts("---> #{src_command.join(' ')}".gsub(redis_url, '[REDACTED]'))
+    $stderr.puts("---> #{src_command.join(' ')}")
     system(*src_command)
   end
 
   0
-end
-
-def heroku_conn(heroku_api_hostname)
-  conn = Net::HTTP.new(heroku_api_hostname, 443)
-  conn.use_ssl = true
-  conn.verify_mode = OpenSSL::SSL::VERIFY_PEER
-  conn
 end
 
 def expand_private!(cidrs)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
`redis-cli` uses a plain http connection. This commit ensures that the non-encrypted connection is made on a secure network.
Also, the `-u` option relies on `redis-cli` >= 4.0. This requirement has been replaced by relying on the internal tool `trvs`.

## What approach did you choose and why?
Make use of internal tooling.

## How can you test this?
`make apply`

## What feedback would you like, if any?
