### PR TITLE
Add librato source name for collectd-vsphere

### DIFF
--- a/modules/collectd_vsphere/collectd_vsphere.tf
+++ b/modules/collectd_vsphere/collectd_vsphere.tf
@@ -87,6 +87,7 @@ resource "null_resource" "collectd_vsphere" {
 ${file(var.config_path)}
 export COLLECTD_VSPHERE_COLLECTD_USERNAME=${var.collectd_vsphere_collectd_network_user}
 export COLLECTD_VSPHERE_COLLECTD_PASSWORD=${var.collectd_vsphere_collectd_network_token}
+export COLLECTD_VSPHERE_LIBRATO_SOURCE='collectd-vsphere-${var.env}-${var.index}'
 EOF
 
     destination = "/tmp/etc-default-collectd-vsphere-${var.env}"


### PR DESCRIPTION
I will test a `make plan` and see what the output has.

## What is the problem that this PR is trying to fix?
Currently collectd metrics aren't reporting to librato as they lack a source.  This does that. 

## What approach did you choose and why?
Copying the patterns used from other apps like travis-worker and jupiter-brain

## How can you test this?

**Added the single line manually** in `/etc/default/collectd-vsphere-common`  for both wjb-1 & wjb-2 
and started the collectd-vsphere service.  

Will check librato for the source names `collectd-vsphere-common-1` and `-2` 

## What feedback would you like, if any?
