### PR TITLE
Updates to get aws-shared-2 working

### DIFF
--- a/aws-shared-2/Makefile
+++ b/aws-shared-2/Makefile
@@ -1,4 +1,7 @@
-include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+AMQP_URL_VARNAME := CLOUDAMQP_URL
+ENV_SHORT := production
+
+include $(shell git rev-parse --show-toplevel)/aws.mk
 
 .PHONY: default
 default: hello


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`make plan` not working due to changes in which files and env vars are expected

## What approach did you choose and why?

Include `$(TOP)/aws.mk` instead of `$(TOP)/terraform-common.mk` and declare a few variables to keep the scripts happy.

## How can you test this?

- [x] works in production!