### PR TITLE
Get aws-shared-1 working again :sweat_smile:

### DIFF
--- a/aws-shared-1/Makefile
+++ b/aws-shared-1/Makefile
@@ -1,4 +1,7 @@
-include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+AMQP_URL_VARNAME := RABBITMQ_BIGWIG_RX_URL
+ENV_SHORT := staging
+
+include $(shell git rev-parse --show-toplevel)/aws.mk
 
 .PHONY: default
 default: hello


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`aws-shared-1` cannot be `make plan`'d :exclamation: 

## What approach did you choose and why?

Alter it similarly to a recent alteration made to `aws-shared-2`.