### PR TITLE
Set asg min size for canary asg to 0

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -292,7 +292,7 @@ module "aws_asg_org_canary" {
   syslog_address              = "${var.syslog_address_org}"
   worker_ami                  = "${var.worker_ami_canary}"
   worker_asg_max_size         = 3
-  worker_asg_min_size         = 1
+  worker_asg_min_size         = 0
   worker_config               = "${data.template_file.worker_config_org.rendered}"
   worker_docker_image_android = "${var.amethyst_image}"
   worker_docker_image_default = "${var.garnet_image}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

follow-up to https://github.com/travis-ci/terraform-config/pull/456, allowing the asg to be set to 0 instances.

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
