### PR TITLE
bump all aws workers to v3.8.0

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -36,7 +36,7 @@ variable "garnet_image" {
 }
 
 variable "worker_image_canary" {
-  default = "travisci/worker:v3.7.0-29-gf54cf99"
+  default = "travisci/worker:v3.8.0"
 }
 
 terraform {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -118,7 +118,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.6.0"
+  default = "travisci/worker:v3.8.0"
 }
 
 variable "worker_instance_type" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Rollout the new v3.8.0 worker to aws production. Mostly to reduce rabbit channel usage via pooling.

refs https://github.com/travis-ci/reliability/issues/100