### PR TITLE
Add a whereami app populated with data from managed DNS

### DIFF
--- a/dns-production-0/Makefile
+++ b/dns-production-0/Makefile
@@ -8,7 +8,7 @@ include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 .config: $(ENV_NAME).auto.tfvars
 
 $(TRVS_INFRA_ENV_TFVARS):
-	@echo "{}" >$@
+	trvs generate-config -f json -a terraform-config -e terraform_common -o $@
 
 $(TRVS_ENV_NAME_TFVARS):
 	@echo "{}" >$@

--- a/dns-production-0/main.tf
+++ b/dns-production-0/main.tf
@@ -196,7 +196,7 @@ resource "null_resource" "whereami" {
 
   provisioner "local-exec" {
     command = <<EOF
-exec ${path.module}/../../bin/heroku-wait-deploy-scale \
+exec ${path.module}/../bin/heroku-wait-deploy-scale \
   --repo=travis-ci/whereami \
   --app=${heroku_app.whereami.id} \
   --ps-scale=${join(",", var.whereami_scale)} \

--- a/dns-production-0/main.tf
+++ b/dns-production-0/main.tf
@@ -1,9 +1,28 @@
+variable "env" {
+  default = "production"
+}
+
+variable "index" {
+  default = 0
+}
+
+variable "heroku_org" {}
+
+variable "macstadium_production_nat_addrs" {
+  type = "list"
+}
+
 variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "macstadium_production_nat_addrs" {
-  type = "list"
+variable "whereami_scale" {
+  type    = "list"
+  default = ["web=1:Standard-1X"]
+}
+
+variable "whereami_version" {
+  default = "master"
 }
 
 terraform {
@@ -17,6 +36,7 @@ terraform {
 }
 
 provider "aws" {}
+provider "heroku" {}
 
 data "dns_a_record_set" "aws_production_2_nat_com" {
   host = "workers-nat-com-shared-2.aws-us-east-1.travisci.net"
@@ -127,4 +147,60 @@ resource "aws_route53_record" "nat" {
     "${var.macstadium_production_nat_addrs}",
     "${data.dns_a_record_set.packet_production_1_nat.addrs}",
   ]
+}
+
+resource "heroku_app" "whereami" {
+  name   = "whereami-${var.env}-${var.index}"
+  region = "us"
+
+  organization {
+    name = "${var.heroku_org}"
+  }
+
+  config_vars {
+    WHEREAMI_INFRA_EC2_IPS = "${
+      join(",", data.dns_a_record_set.aws_production_2_nat_com.addrs)
+    },${
+      join(",", data.dns_a_record_set.aws_production_2_nat_org.addrs)
+    }"
+
+    WHEREAMI_INFRA_GCE_IPS = "${
+      join(",", data.dns_a_record_set.gce_production_1_nat.addrs)
+    },${
+      join(",", data.dns_a_record_set.gce_production_2_nat.addrs)
+    },${
+      join(",", data.dns_a_record_set.gce_production_3_nat.addrs)
+    },${
+      join(",", data.dns_a_record_set.gce_production_4_nat.addrs)
+    },${
+      join(",", data.dns_a_record_set.gce_production_5_nat.addrs)
+    }"
+
+    WHEREAMI_INFRA_MACSTADIUM_IPS = "${
+      join(",", var.macstadium_production_nat_addrs)
+    }"
+
+    WHEREAMI_INFRA_PACKET_IPS = "${
+      join(",", data.dns_a_record_set.packet_production_1_nat.addrs)
+    }"
+  }
+}
+
+resource "null_resource" "whereami" {
+  triggers {
+    config_signature = "${sha256(join(",", values(heroku_app.whereami.config_vars.0)))}"
+    heroku_id        = "${heroku_app.whereami.id}"
+    scale            = "${join(",", var.whereami_scale)}"
+    version          = "${var.whereami_version}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+exec ${path.module}/../../bin/heroku-wait-deploy-scale \
+  --repo=travis-ci/whereami \
+  --app=${heroku_app.whereami.id} \
+  --ps-scale=${join(",", var.whereami_scale)} \
+  --deploy-version=${var.whereami_version}
+EOF
+  }
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The `chirp` code does not have a reliable way to detect on which infrastructure it is running (which is why [whereami](https://github.com/travis-ci/whereami) exists).

## What approach did you choose and why?

Provision an instance of whereami populated with data from the managed DNS records.