### PR TITLE
Bump pupcycler version to v0.1.2 in packet production

### DIFF
--- a/modules/pupcycler/main.tf
+++ b/modules/pupcycler/main.tf
@@ -17,7 +17,7 @@ variable "scale" {
 variable "syslog_address" {}
 
 variable "version" {
-  default = "v0.1.0"
+  default = "v0.1.2"
 }
 
 resource "heroku_app" "pupcycler" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Having the freshest goodies in production

## What approach did you choose and why?
Adjust the default version in the module.

## How can you test this?

## What feedback would you like, if any?
