### PR TITLE
Automatically use next available Packet hardware reservation

### DIFF
--- a/modules/packet_network/main.tf
+++ b/modules/packet_network/main.tf
@@ -108,6 +108,8 @@ resource "packet_device" "nat" {
   user_data        = "${element(data.template_file.nat_user_data.*.rendered, count.index)}"
   tags             = ["nat", "${var.env}"]
 
+  hardware_reservation_id = "next-available"
+
   lifecycle {
     ignore_changes = ["root_password", "user_data"]
   }

--- a/modules/packet_worker/main.tf
+++ b/modules/packet_worker/main.tf
@@ -140,6 +140,8 @@ resource "packet_device" "worker" {
   user_data        = "${element(data.template_file.user_data.*.rendered, count.index)}"
   tags             = ["worker", "${var.site}", "${var.env}"]
 
+  hardware_reservation_id = "next-available"
+
   lifecycle {
     ignore_changes = ["root_password", "user_data"]
   }


### PR DESCRIPTION
instead of defaulting to the on-demand pool or keeping track of hardware reservation ids ourselves.  Feature available [as described here](https://www.terraform.io/docs/providers/packet/r/device.html#hardware_reservation_id).