### PR TITLE
Managed AWS resources to be used by chirp repos

### DIFF
--- a/bin/chirp-assign-aws-creds
+++ b/bin/chirp-assign-aws-creds
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -o errexit
+
+main() {
+  local access_key_id="${1}"
+  shift
+  local secret_key="${1}"
+  shift
+
+  for repo in "${@}"; do
+    travis env set -r "${repo}" AWS_ACCESS_KEY "${access_key_id}"
+    travis env set -r "${repo}" AWS_SECRET_KEY "${secret_key}"
+  done
+}
+
+main "${@}"

--- a/chirp-production-1/Makefile
+++ b/chirp-production-1/Makefile
@@ -1,0 +1,13 @@
+include $(shell git rev-parse --show-toplevel)/terraform-common.mk
+
+.PHONY: .config
+.config: $(ENV_NAME).auto.tfvars
+
+$(TRVS_INFRA_ENV_TFVARS):
+	trvs generate-config -f json -a terraform-config -e terraform_common -o $@
+
+$(TRVS_ENV_NAME_TFVARS):
+	@echo "{}" >$@
+
+$(ENV_NAME).auto.tfvars:
+	@echo "{}" >$@

--- a/chirp-production-1/main.tf
+++ b/chirp-production-1/main.tf
@@ -67,6 +67,17 @@ EOF
   depends_on = ["aws_iam_user.chirp"]
 }
 
+resource "local_file" "chirp_key" {
+  content = <<EOF
+{
+  "id": ${jsonencode(aws_iam_access_key.chirp.id)},
+  "secret": ${jsonencode(aws_iam_access_key.chirp.secret)}
+}
+EOF
+
+  filename = "${path.module}/../tmp/chirp-key.json"
+}
+
 resource "null_resource" "chirp_key_vars" {
   triggers {
     chirp_iam_access_key = "${sha256("${aws_iam_access_key.chirp.id}")}"

--- a/chirp-production-1/main.tf
+++ b/chirp-production-1/main.tf
@@ -1,0 +1,81 @@
+variable "chirp_artifacts_bucket_name" {
+  default = "travis-ci-chirp-artifacts"
+}
+
+variable "chirp_org_production_repo" {
+  default = "travis-repos/chirp-org-production"
+}
+
+variable "chirp_com_production_repo" {
+  default = "travis-infrastructure/chirp-com-production"
+}
+
+variable "env" {
+  default = "production"
+}
+
+variable "index" {
+  default = 1
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+provider "aws" {}
+
+resource "aws_s3_bucket" "chirp_artifacts" {
+  bucket = "${var.chirp_artifacts_bucket_name}"
+}
+
+resource "aws_iam_user" "chirp" {
+  name = "chirp-${var.env}-${var.index}"
+}
+
+resource "aws_iam_access_key" "chirp" {
+  user       = "${aws_iam_user.chirp.name}"
+  depends_on = ["aws_iam_user.chirp"]
+}
+
+resource "aws_iam_user_policy" "chirp_actions" {
+  name = "chirp_actions_${var.env}_${var.index}"
+  user = "${aws_iam_user.chirp.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.chirp_artifacts.arn}",
+        "${aws_s3_bucket.chirp_artifacts.arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+
+  depends_on = ["aws_iam_user.chirp"]
+}
+
+resource "null_resource" "chirp_key_vars" {
+  triggers {
+    chirp_iam_access_key = "${sha256("${aws_iam_access_key.chirp.id}")}"
+    chirp_iam_secret_key = "${sha256("${aws_iam_access_key.chirp.secret}")}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+exec ${path.module}/../bin/chirp-assign-aws-creds \
+  "${aws_iam_access_key.chirp.id}" \
+  "${aws_iam_access_key.chirp.secret}" \
+  "${var.chirp_org_production_repo}" \
+  "${var.chirp_com_production_repo}"
+EOF
+  }
+}

--- a/chirp-production-1/main.tf
+++ b/chirp-production-1/main.tf
@@ -2,12 +2,16 @@ variable "chirp_artifacts_bucket_name" {
   default = "travis-ci-chirp-artifacts"
 }
 
+variable "chirp_com_production_repo" {
+  default = "travis-infrastructure/chirp-com-production"
+}
+
 variable "chirp_org_production_repo" {
   default = "travis-repos/chirp-org-production"
 }
 
-variable "chirp_com_production_repo" {
-  default = "travis-infrastructure/chirp-com-production"
+variable "chirp_repo" {
+  default = "travis-ci/chirp"
 }
 
 variable "env" {
@@ -74,6 +78,7 @@ resource "null_resource" "chirp_key_vars" {
 exec ${path.module}/../bin/chirp-assign-aws-creds \
   "${aws_iam_access_key.chirp.id}" \
   "${aws_iam_access_key.chirp.secret}" \
+  "${var.chirp_repo}" \
   "${var.chirp_org_production_repo}" \
   "${var.chirp_com_production_repo}"
 EOF


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The chirp repo(s) do not currently test S3 up/down, but will :soon:, and will need some S3 bits in place.

## What approach did you choose and why?

Place the S3 bits.