### PR TITLE
Bump travis-worker to v3.8.2

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -36,7 +36,7 @@ variable "garnet_image" {
 }
 
 variable "worker_image_canary" {
-  default = "travisci/worker:v3.8.0"
+  default = "travisci/worker:v3.8.2"
 }
 
 terraform {

--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.6.0"
+  default = "v3.8.2"
 }
 
 data "template_file" "worker_config_common" {

--- a/macstadium-pod-2/workers.tf
+++ b/macstadium-pod-2/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.6.0"
+  default = "v3.8.2"
 }
 
 data "template_file" "worker_config_common" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -93,7 +93,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.0"
+  default = "travisci/worker:v3.8.2"
 }
 
 variable "worker_instance_type" {

--- a/modules/aws_asg_canary/main.tf
+++ b/modules/aws_asg_canary/main.tf
@@ -51,7 +51,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.6.0"
+  default = "travisci/worker:v3.8.2"
 }
 
 variable "worker_instance_type" {

--- a/modules/aws_asg_queue/main.tf
+++ b/modules/aws_asg_queue/main.tf
@@ -93,7 +93,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.0"
+  default = "travisci/worker:v3.8.2"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -39,7 +39,7 @@ variable "worker_config_com_free" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.0"
+  default = "travisci/worker:v3.8.2"
 }
 
 variable "worker_image" {}

--- a/modules/packet_worker/main.tf
+++ b/modules/packet_worker/main.tf
@@ -45,7 +45,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.0"
+  default = "travisci/worker:v3.8.2"
 }
 
 data "tls_public_key" "terraform" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Any travis-worker versions prior to v3.8.2 in production

## What approach did you choose and why?

Alter version strings to be v3.8.2 :sparkles: 

## How can you test this?

Very Carefully :crossed_fingers: 