### PR TITLE
Pod-1 worker pool size tweak

### DIFF
--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -32,7 +32,7 @@ module "worker_production_org_1" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="60"
+export TRAVIS_WORKER_POOL_SIZE="57"
 export TRAVIS_WORKER_PPROF_PORT="7070"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-1-dc18"
@@ -52,7 +52,7 @@ module "worker_production_org_2" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="60"
+export TRAVIS_WORKER_POOL_SIZE="57"
 export TRAVIS_WORKER_PPROF_PORT="7071"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-org-macstadium-${var.index}-2-dc18"
@@ -111,7 +111,7 @@ module "worker_production_com_1" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="40"
+export TRAVIS_WORKER_POOL_SIZE="37"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-1-dc18"
 EOF
@@ -131,7 +131,7 @@ module "worker_production_com_2" {
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
 export TRAVIS_WORKER_TRAVIS_SITE="com"
-export TRAVIS_WORKER_POOL_SIZE="40"
+export TRAVIS_WORKER_POOL_SIZE="37"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_com_token.hex}@127.0.0.1:8083/"
 export TRAVIS_WORKER_LIBRATO_SOURCE="travis-worker-production-com-macstadium-${var.index}-2-dc18"
 EOF


### PR DESCRIPTION

## What is the problem that this PR is trying to fix?
The change in https://github.com/travis-ci/packer-templates/pull/630
introduces a dedicated macpro to run packer builds for xcode build
images for the mac infra. We decided to provision this macpro from the
existing `Macpro_Pod_1` shared compute cluster.  As a result, worker
pool sizes need to change slightly so that the remaining macpros do not get
overencumbered during peak demand.

## What approach did you choose and why?

While this introduces other manual steps elsewhere in the packer build pipeline for xcode images
(see [this comment](https://github.com/travis-ci/packer-templates/pull/629#discussion_r197119741) ) that are the responsibility of the dev running the packer-build, this decision was made to alleviate the long feedback loops during the image making process due to CPU bottlenecks in smaller vms. 

## How can you test this?

Terraform plan output

## What feedback would you like, if any?
