### PR TITLE
Add compute.globalOperations.list to permissions

### DIFF
--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -61,6 +61,8 @@ resource "google_project_iam_custom_role" "worker" {
     "compute.disks.update",
     "compute.disks.use",
     "compute.disks.useReadOnly",
+    "compute.globalOperations.get",
+    "compute.globalOperations.list",
     "compute.instances.addAccessConfig",
     "compute.instances.addMaintenancePolicies",
     "compute.instances.attachDisk",

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -110,6 +110,7 @@ resource "google_project_iam_custom_role" "gcloud_cleaner" {
     "compute.disks.get",
     "compute.disks.list",
     "compute.disks.update",
+    "compute.globalOperations.list",
     "compute.images.delete",
     "compute.images.get",
     "compute.images.list",

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -110,6 +110,7 @@ resource "google_project_iam_custom_role" "gcloud_cleaner" {
     "compute.disks.get",
     "compute.disks.list",
     "compute.disks.update",
+    "compute.globalOperations.get",
     "compute.globalOperations.list",
     "compute.images.delete",
     "compute.images.get",


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Requeues at end of script due to:

```
msg="couldn't determine if instance was preempted" err="googleapi: Error 403: Required 'compute.globalOperations.list' permission for 'projects/travis-staging-1', forbidden" 
```

## What approach did you choose and why?
Add the permission that the API is complaining about.

## How can you test this?

## What feedback would you like, if any?
