### PR TITLE
Upgrade worker to version 3.9.0

### DIFF
--- a/macstadium-pod-1/workers.tf
+++ b/macstadium-pod-1/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.8.2"
+  default = "v3.9.0"
 }
 
 data "template_file" "worker_config_common" {

--- a/macstadium-pod-2/workers.tf
+++ b/macstadium-pod-2/workers.tf
@@ -1,7 +1,7 @@
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.8.2"
+  default = "v3.9.0"
 }
 
 data "template_file" "worker_config_common" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -93,7 +93,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.2"
+  default = "travisci/worker:v3.9.0"
 }
 
 variable "worker_instance_type" {

--- a/modules/aws_asg_canary/main.tf
+++ b/modules/aws_asg_canary/main.tf
@@ -51,7 +51,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.2"
+  default = "travisci/worker:v3.9.0"
 }
 
 variable "worker_instance_type" {

--- a/modules/aws_asg_queue/main.tf
+++ b/modules/aws_asg_queue/main.tf
@@ -93,7 +93,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.2"
+  default = "travisci/worker:v3.9.0"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -40,7 +40,7 @@ variable "worker_config_com_free" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.2"
+  default = "travisci/worker:v3.9.0"
 }
 
 variable "worker_image" {}

--- a/modules/packet_worker/main.tf
+++ b/modules/packet_worker/main.tf
@@ -45,7 +45,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v3.8.2"
+  default = "travisci/worker:v3.9.0"
 }
 
 data "tls_public_key" "terraform" {


### PR DESCRIPTION
Release info here: https://github.com/travis-ci/worker/releases/tag/v3.9.0
Reference issue: https://github.com/travis-ci/reliability/issues/134