### PR TITLE
Ensure worker on GCE can allocate external IPs

### DIFF
--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -111,6 +111,7 @@ resource "google_project_iam_custom_role" "worker" {
     "compute.subnetworks.get",
     "compute.subnetworks.list",
     "compute.subnetworks.use",
+    "compute.subnetworks.useExternalIp",
     "compute.zoneOperations.get",
     "compute.zoneOperations.list",
     "compute.zones.get",


### PR DESCRIPTION
as is required when running with:

``` yaml
export TRAVIS_WORKER_GCE_PUBLIC_IP=true
export TRAVIS_WORKER_GCE_PUBLIC_IP_CONNECT=true
```