### PR TITLE
gce-production-1: create single com-free worker

### DIFF
--- a/gce-production-1/instance-counts.auto.tfvars
+++ b/gce-production-1/instance-counts.auto.tfvars
@@ -1,4 +1,5 @@
 {
   "worker_instance_count_com": 18,
-  "worker_instance_count_org": 21
+  "worker_instance_count_org": 21,
+  "worker_instance_count_com_free": 1
 }

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -25,10 +25,7 @@ variable "travisci_net_external_zone_id" {
 
 variable "worker_instance_count_com" {}
 variable "worker_instance_count_org" {}
-
-variable "worker_instance_count_com_free" {
-  default = "0"
-}
+variable "worker_instance_count_com_free" {}
 
 variable "worker_zones" {
   default = ["a", "b", "f"]


### PR DESCRIPTION
This is the minimal production rollout of the "com-free" worker pools. The staging version was https://github.com/travis-ci/reliability/issues/117.

This should be a non-invasive change and safe to apply.

We can test it by checking if the `builds.gce-free` queue gets created on com production rabbit.

refs https://github.com/travis-ci/reliability/issues/127