### PR TITLE
Use the default nat image for staging instead of the latest one

### DIFF
--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -65,7 +65,11 @@ module "gce_net" {
   bastion_image                 = "${var.latest_gce_bastion_image}"
   deny_target_ip_ranges         = ["${split(",", var.deny_target_ip_ranges)}"]
   env                           = "${var.env}"
-  gesund_self_image             = "${var.latest_docker_image_gesund}"
+
+  # TODO: replace with var.latest_docker_image_gesund when 
+  # https://github.com/travis-ci/packer-templates/issues/640 is fixed
+  gesund_self_image             = "travisci/gesund:0.1.0"
+
   github_users                  = "${var.github_users}"
   heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
@@ -75,7 +79,11 @@ module "gce_net" {
   nat_conntracker_redis_plan    = "hobby-dev"
   nat_conntracker_self_image    = "${var.latest_docker_image_nat_conntracker}"
   nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
-  nat_image                     = "${var.latest_gce_tfw_image}"
+
+  # TODO: replace with var.latest_gce_tfw_image when
+  # https://github.com/travis-ci/packer-templates/issues/640 is fixed
+  nat_image                     = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
+
   nat_machine_type              = "g1-small"
   project                       = "${var.project}"
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -61,28 +61,28 @@ provider "heroku" {}
 module "gce_net" {
   source = "../modules/gce_net"
 
-  bastion_config                = "${file("config/bastion.env")}"
-  bastion_image                 = "${var.latest_gce_bastion_image}"
-  deny_target_ip_ranges         = ["${split(",", var.deny_target_ip_ranges)}"]
-  env                           = "${var.env}"
+  bastion_config        = "${file("config/bastion.env")}"
+  bastion_image         = "${var.latest_gce_bastion_image}"
+  deny_target_ip_ranges = ["${split(",", var.deny_target_ip_ranges)}"]
+  env                   = "${var.env}"
 
-  # TODO: replace with var.latest_docker_image_gesund when 
+  # TODO: replace with var.latest_docker_image_gesund when
   # https://github.com/travis-ci/packer-templates/issues/640 is fixed
-  gesund_self_image             = "travisci/gesund:0.1.0"
+  gesund_self_image = "travisci/gesund:0.1.0"
 
-  github_users                  = "${var.github_users}"
-  heroku_org                    = "${var.gce_heroku_org}"
-  index                         = "${var.index}"
-  nat_config                    = "${file("config/nat.env")}"
-  nat_conntracker_config        = "${file("nat-conntracker.env")}"
-  nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
-  nat_conntracker_redis_plan    = "hobby-dev"
-  nat_conntracker_self_image    = "${var.latest_docker_image_nat_conntracker}"
-  nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
+  github_users               = "${var.github_users}"
+  heroku_org                 = "${var.gce_heroku_org}"
+  index                      = "${var.index}"
+  nat_config                 = "${file("config/nat.env")}"
+  nat_conntracker_config     = "${file("nat-conntracker.env")}"
+  nat_conntracker_dst_ignore = ["${var.nat_conntracker_dst_ignore}"]
+  nat_conntracker_redis_plan = "hobby-dev"
+  nat_conntracker_self_image = "${var.latest_docker_image_nat_conntracker}"
+  nat_conntracker_src_ignore = ["${var.nat_conntracker_src_ignore}"]
 
   # TODO: replace with var.latest_gce_tfw_image when
   # https://github.com/travis-ci/packer-templates/issues/640 is fixed
-  nat_image                     = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
+  nat_image = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
 
   nat_machine_type              = "g1-small"
   project                       = "${var.project}"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -102,36 +102,39 @@ resource "google_compute_network" "main" {
 }
 
 resource "google_compute_subnetwork" "public" {
-  name          = "public"
-  ip_cidr_range = "${var.public_subnet_cidr_range}"
-  network       = "${google_compute_network.main.self_link}"
-  region        = "${var.region}"
-  project       = "${var.project}"
+  name             = "public"
+  ip_cidr_range    = "${var.public_subnet_cidr_range}"
+  network          = "${google_compute_network.main.self_link}"
+  region           = "${var.region}"
+  project          = "${var.project}"
+  enable_flow_logs = "true"
 }
 
 resource "google_compute_subnetwork" "workers" {
-  name          = "workers"
-  ip_cidr_range = "${var.workers_subnet_cidr_range}"
-  network       = "${google_compute_network.main.self_link}"
-  region        = "${var.region}"
-  project       = "${var.project}"
+  name             = "workers"
+  ip_cidr_range    = "${var.workers_subnet_cidr_range}"
+  network          = "${google_compute_network.main.self_link}"
+  region           = "${var.region}"
+  project          = "${var.project}"
+  enable_flow_logs = "true"
 }
 
 resource "google_compute_subnetwork" "jobs_org" {
-  name          = "jobs-org"
-  ip_cidr_range = "${var.jobs_org_subnet_cidr_range}"
-  network       = "${google_compute_network.main.self_link}"
-  region        = "${var.region}"
-  project       = "${var.project}"
+  name             = "jobs-org"
+  ip_cidr_range    = "${var.jobs_org_subnet_cidr_range}"
+  network          = "${google_compute_network.main.self_link}"
+  region           = "${var.region}"
+  project          = "${var.project}"
+  enable_flow_logs = "true"
 }
 
 resource "google_compute_subnetwork" "jobs_com" {
-  name          = "jobs-com"
-  ip_cidr_range = "${var.jobs_com_subnet_cidr_range}"
-  network       = "${google_compute_network.main.self_link}"
-  region        = "${var.region}"
-
-  project = "${var.project}"
+  name             = "jobs-com"
+  ip_cidr_range    = "${var.jobs_com_subnet_cidr_range}"
+  network          = "${google_compute_network.main.self_link}"
+  region           = "${var.region}"
+  project          = "${var.project}"
+  enable_flow_logs = "true"
 }
 
 resource "google_compute_firewall" "allow_main_ssh" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/packer-templates/issues/640

## What approach did you choose and why?
Until the instance_templates issues are fixed, we should keep staging working. 
Using the default images (the ones that the production NATs are using as well) seems to work fine.

## How can you test this?
It's successfully running on all the NATs on staging.

## What feedback would you like, if any?
