### PR TITLE
Send Slack notifications for both macstadium pods

### DIFF
--- a/bin/post-flight
+++ b/bin/post-flight
@@ -11,7 +11,7 @@ main() {
   local graphname
   graphname="$(basename "$(pwd)")"
 
-  if [[ "${graphname}" != *production* ]] && [[ "${graphname}" != *2* ]]; then
+  if [[ "${graphname}" != *production* ]] && [[ "${graphname}" != *macstadium-pod* ]]; then
     echo "Skipping Slack notification for '${graphname}'"
     exit 0
   fi


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The post flight script never sends Slack notifications for macstadium-pod-1.

## What approach did you choose and why?

Changed the logic to send notifications if the graph directory includes either `production` or `macstadium-pod` in its name.

## How can you test this?

Ran `make apply` in the `macstadium-pod-1` graph directory, and it sent a notification!

## What feedback would you like, if any?

I don't really understand why the previous logic included non-production graph directories with a `2` in the name. Does somebody know what that was for?