### PR TITLE
manage gce workers via instance groups

### DIFF
--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -98,9 +98,13 @@ module "gce_worker_group" {
 
   worker_zones = "${var.worker_zones}"
 
-  worker_instance_count_com      = "${length(var.worker_zones)}"
-  worker_instance_count_com_free = "1"
-  worker_instance_count_org      = "${length(var.worker_zones)}"
+  worker_instance_count_com      = "0"
+  worker_instance_count_com_free = "0"
+  worker_instance_count_org      = "0"
+
+  worker_managed_instance_count_com      = "${length(var.worker_zones)}"
+  worker_managed_instance_count_com_free = "1"
+  worker_managed_instance_count_org      = "${length(var.worker_zones)}"
 
   worker_config_com = <<EOF
 ### worker.env

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -300,7 +300,7 @@ resource "google_compute_instance_template" "worker_com_free" {
   name_prefix = "${var.env}-${var.index}-worker-com-free-template-"
 
   machine_type = "${var.machine_type}"
-  tags         = ["worker", "${var.env}", "com", "free", "foo"]
+  tags         = ["worker", "${var.env}", "com", "free"]
   project      = "${var.project}"
 
   scheduling {

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -170,8 +170,7 @@ EOF
 }
 
 resource "google_compute_instance_template" "worker_com" {
-  count = "${length(var.zones)}"
-  name  = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com.rendered}"), 0, 7)}"
+  name_prefix = "${var.env}-${var.index}-worker-com-template-"
 
   machine_type = "${var.machine_type}"
   tags         = ["worker", "${var.env}", "com", "paid"]
@@ -204,21 +203,19 @@ resource "google_compute_instance_template" "worker_com" {
   # TODO: port null_resource.worker_com_validation to instance group
 
   lifecycle {
-    ignore_changes = ["disk", "boot_disk"]
-
     create_before_destroy = true
   }
 }
 
-resource "google_compute_instance_group_manager" "worker_com" {
-  count = "${length(var.zones)}"
-
-  base_instance_name = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index)}"
-  instance_template  = "${element(google_compute_instance_template.worker_com.*.self_link, count.index)}"
-  name               = "worker-com-${element(var.zones, count.index)}"
+resource "google_compute_region_instance_group_manager" "worker_com" {
+  base_instance_name = "${var.env}-${var.index}-worker-com"
+  instance_template  = "${google_compute_instance_template.worker_com.self_link}"
+  name               = "worker-com"
   target_size        = "${var.instance_count_com}"
   update_strategy    = "NONE"
-  zone               = "${var.region}-${element(var.zones, count.index)}"
+  region             = "${var.region}"
+
+  distribution_policy_zones = "${formatlist("${var.region}-%s", var.zones)}"
 }
 
 resource "google_compute_instance" "worker_com" {
@@ -300,11 +297,10 @@ EOF
 }
 
 resource "google_compute_instance_template" "worker_com_free" {
-  count = "${length(var.zones)}"
-  name  = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com_free.rendered}"), 0, 7)}"
+  name_prefix = "${var.env}-${var.index}-worker-com-free-template-"
 
   machine_type = "${var.machine_type}"
-  tags         = ["worker", "${var.env}", "com", "free"]
+  tags         = ["worker", "${var.env}", "com", "free", "foo"]
   project      = "${var.project}"
 
   scheduling {
@@ -334,21 +330,19 @@ resource "google_compute_instance_template" "worker_com_free" {
   # TODO: port null_resource.worker_com_validation to instance group
 
   lifecycle {
-    ignore_changes = ["disk", "boot_disk"]
-
     create_before_destroy = true
   }
 }
 
-resource "google_compute_instance_group_manager" "worker_com_free" {
-  count = "${length(var.zones)}"
-
-  base_instance_name = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index)}"
-  instance_template  = "${element(google_compute_instance_template.worker_com_free.*.self_link, count.index)}"
-  name               = "worker-com-free-${element(var.zones, count.index)}"
+resource "google_compute_region_instance_group_manager" "worker_com_free" {
+  base_instance_name = "${var.env}-${var.index}-worker-com-free"
+  instance_template  = "${google_compute_instance_template.worker_com_free.self_link}"
+  name               = "worker-com-free"
   target_size        = "${var.instance_count_com_free}"
   update_strategy    = "NONE"
-  zone               = "${var.region}-${element(var.zones, count.index)}"
+  region             = "${var.region}"
+
+  distribution_policy_zones = "${formatlist("${var.region}-%s", var.zones)}"
 }
 
 resource "google_compute_instance" "worker_com_free" {
@@ -430,8 +424,7 @@ EOF
 }
 
 resource "google_compute_instance_template" "worker_org" {
-  count = "${length(var.zones)}"
-  name  = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_org.rendered}"), 0, 7)}"
+  name_prefix = "${var.env}-${var.index}-worker-org-template-"
 
   machine_type = "${var.machine_type}"
   tags         = ["worker", "${var.env}", "org"]
@@ -464,21 +457,19 @@ resource "google_compute_instance_template" "worker_org" {
   # TODO: port null_resource.worker_org_validation to instance group
 
   lifecycle {
-    ignore_changes = ["disk", "boot_disk"]
-
     create_before_destroy = true
   }
 }
 
-resource "google_compute_instance_group_manager" "worker_org" {
-  count = "${length(var.zones)}"
-
-  base_instance_name = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index)}"
-  instance_template  = "${element(google_compute_instance_template.worker_org.*.self_link, count.index)}"
-  name               = "worker-org-${element(var.zones, count.index)}"
+resource "google_compute_region_instance_group_manager" "worker_org" {
+  base_instance_name = "${var.env}-${var.index}-worker-org"
+  instance_template  = "${google_compute_instance_template.worker_org.self_link}"
+  name               = "worker-org"
   target_size        = "${var.instance_count_org}"
   update_strategy    = "NONE"
-  zone               = "${var.region}-${element(var.zones, count.index)}"
+  region             = "${var.region}"
+
+  distribution_policy_zones = "${formatlist("${var.region}-%s", var.zones)}"
 }
 
 resource "google_compute_instance" "worker_org" {

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -170,8 +170,8 @@ EOF
 }
 
 resource "google_compute_instance_template" "worker_com" {
-  count          = "${length(var.zones)}"
-  name           = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com.rendered}"), 0, 7)}"
+  count = "${length(var.zones)}"
+  name  = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com.rendered}"), 0, 7)}"
 
   machine_type = "${var.machine_type}"
   tags         = ["worker", "${var.env}", "com", "paid"]
@@ -298,8 +298,8 @@ EOF
 }
 
 resource "google_compute_instance_template" "worker_com_free" {
-  count          = "${length(var.zones)}"
-  name           = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com_free.rendered}"), 0, 7)}"
+  count = "${length(var.zones)}"
+  name  = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com_free.rendered}"), 0, 7)}"
 
   machine_type = "${var.machine_type}"
   tags         = ["worker", "${var.env}", "com", "free"]
@@ -426,8 +426,8 @@ EOF
 }
 
 resource "google_compute_instance_template" "worker_org" {
-  count          = "${length(var.zones)}"
-  name           = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_org.rendered}"), 0, 7)}"
+  count = "${length(var.zones)}"
+  name  = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_org.rendered}"), 0, 7)}"
 
   machine_type = "${var.machine_type}"
   tags         = ["worker", "${var.env}", "org"]

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -169,6 +169,56 @@ EOF
   }
 }
 
+resource "google_compute_instance_template" "worker_com" {
+  count          = "${length(var.zones)}"
+  name           = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com.rendered}"), 0, 7)}"
+
+  machine_type = "${var.machine_type}"
+  tags         = ["worker", "${var.env}", "com", "paid"]
+  project      = "${var.project}"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = "${var.worker_image}"
+  }
+
+  network_interface {
+    subnetwork = "${var.subnetwork_workers}"
+
+    access_config {
+      # ephemeral ip
+    }
+  }
+
+  metadata {
+    "block-project-ssh-keys" = "true"
+    "user-data"              = "${data.template_file.cloud_config_com.rendered}"
+  }
+
+  # TODO: port null_resource.worker_com_validation to instance group
+
+  lifecycle {
+    ignore_changes = ["disk", "boot_disk"]
+  }
+}
+
+resource "google_compute_instance_group_manager" "worker_com" {
+  count = "${length(var.zones)}"
+
+  base_instance_name = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index)}"
+  instance_template  = "${element(google_compute_instance_template.worker_com.*.self_link, count.index)}"
+  name               = "worker-com-${element(var.zones, count.index)}"
+  target_size        = "${var.instance_count_com}"
+  update_strategy    = "NONE"
+  zone               = "${var.region}-${element(var.zones, count.index)}"
+}
+
 resource "google_compute_instance" "worker_com" {
   count = "${var.instance_count_com}"
   name  = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
@@ -247,6 +297,56 @@ EOF
   }
 }
 
+resource "google_compute_instance_template" "worker_com_free" {
+  count          = "${length(var.zones)}"
+  name           = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_com_free.rendered}"), 0, 7)}"
+
+  machine_type = "${var.machine_type}"
+  tags         = ["worker", "${var.env}", "com", "free"]
+  project      = "${var.project}"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = "${var.worker_image}"
+  }
+
+  network_interface {
+    subnetwork = "${var.subnetwork_workers}"
+
+    access_config {
+      # ephemeral ip
+    }
+  }
+
+  metadata {
+    "block-project-ssh-keys" = "true"
+    "user-data"              = "${data.template_file.cloud_config_com_free.rendered}"
+  }
+
+  # TODO: port null_resource.worker_com_validation to instance group
+
+  lifecycle {
+    ignore_changes = ["disk", "boot_disk"]
+  }
+}
+
+resource "google_compute_instance_group_manager" "worker_com_free" {
+  count = "${length(var.zones)}"
+
+  base_instance_name = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index)}"
+  instance_template  = "${element(google_compute_instance_template.worker_com_free.*.self_link, count.index)}"
+  name               = "worker-com-free-${element(var.zones, count.index)}"
+  target_size        = "${var.instance_count_com_free}"
+  update_strategy    = "NONE"
+  zone               = "${var.region}-${element(var.zones, count.index)}"
+}
+
 resource "google_compute_instance" "worker_com_free" {
   count = "${var.instance_count_com_free}"
   name  = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
@@ -323,6 +423,56 @@ exec ${path.module}/../../bin/travis-worker-verify-config \
   "${base64encode(data.template_file.cloud_config_org.rendered)}"
 EOF
   }
+}
+
+resource "google_compute_instance_template" "worker_org" {
+  count          = "${length(var.zones)}"
+  name           = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index)}-template-${substr(sha256("${var.worker_image}${data.template_file.cloud_config_org.rendered}"), 0, 7)}"
+
+  machine_type = "${var.machine_type}"
+  tags         = ["worker", "${var.env}", "org"]
+  project      = "${var.project}"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = "${var.worker_image}"
+  }
+
+  network_interface {
+    subnetwork = "${var.subnetwork_workers}"
+
+    access_config {
+      # ephemeral ip
+    }
+  }
+
+  metadata {
+    "block-project-ssh-keys" = "true"
+    "user-data"              = "${data.template_file.cloud_config_org.rendered}"
+  }
+
+  # TODO: port null_resource.worker_org_validation to instance group
+
+  lifecycle {
+    ignore_changes = ["disk", "boot_disk"]
+  }
+}
+
+resource "google_compute_instance_group_manager" "worker_org" {
+  count = "${length(var.zones)}"
+
+  base_instance_name = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index)}"
+  instance_template  = "${element(google_compute_instance_template.worker_org.*.self_link, count.index)}"
+  name               = "worker-org-${element(var.zones, count.index)}"
+  target_size        = "${var.instance_count_org}"
+  update_strategy    = "NONE"
+  zone               = "${var.region}-${element(var.zones, count.index)}"
 }
 
 resource "google_compute_instance" "worker_org" {

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -7,6 +7,9 @@ variable "index" {}
 variable "instance_count_com" {}
 variable "instance_count_com_free" {}
 variable "instance_count_org" {}
+variable "managed_instance_count_com" {}
+variable "managed_instance_count_com_free" {}
+variable "managed_instance_count_org" {}
 
 variable "machine_type" {
   default = "n1-standard-1"
@@ -211,7 +214,7 @@ resource "google_compute_region_instance_group_manager" "worker_com" {
   base_instance_name = "${var.env}-${var.index}-worker-com"
   instance_template  = "${google_compute_instance_template.worker_com.self_link}"
   name               = "worker-com"
-  target_size        = "${var.instance_count_com}"
+  target_size        = "${var.managed_instance_count_com}"
   update_strategy    = "NONE"
   region             = "${var.region}"
 
@@ -338,7 +341,7 @@ resource "google_compute_region_instance_group_manager" "worker_com_free" {
   base_instance_name = "${var.env}-${var.index}-worker-com-free"
   instance_template  = "${google_compute_instance_template.worker_com_free.self_link}"
   name               = "worker-com-free"
-  target_size        = "${var.instance_count_com_free}"
+  target_size        = "${var.managed_instance_count_com_free}"
   update_strategy    = "NONE"
   region             = "${var.region}"
 
@@ -465,7 +468,7 @@ resource "google_compute_region_instance_group_manager" "worker_org" {
   base_instance_name = "${var.env}-${var.index}-worker-org"
   instance_template  = "${google_compute_instance_template.worker_org.self_link}"
   name               = "worker-org"
-  target_size        = "${var.instance_count_org}"
+  target_size        = "${var.managed_instance_count_org}"
   update_strategy    = "NONE"
   region             = "${var.region}"
 

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -205,6 +205,8 @@ resource "google_compute_instance_template" "worker_com" {
 
   lifecycle {
     ignore_changes = ["disk", "boot_disk"]
+
+    create_before_destroy = true
   }
 }
 
@@ -333,6 +335,8 @@ resource "google_compute_instance_template" "worker_com_free" {
 
   lifecycle {
     ignore_changes = ["disk", "boot_disk"]
+
+    create_before_destroy = true
   }
 }
 
@@ -461,6 +465,8 @@ resource "google_compute_instance_template" "worker_org" {
 
   lifecycle {
     ignore_changes = ["disk", "boot_disk"]
+
+    create_before_destroy = true
   }
 }
 

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -200,7 +200,7 @@ resource "google_compute_instance_template" "worker_com" {
     "user-data"              = "${data.template_file.cloud_config_com.rendered}"
   }
 
-  # TODO: port null_resource.worker_com_validation to instance group
+  depends_on = ["null_resource.worker_com_validation"]
 
   lifecycle {
     create_before_destroy = true
@@ -327,7 +327,7 @@ resource "google_compute_instance_template" "worker_com_free" {
     "user-data"              = "${data.template_file.cloud_config_com_free.rendered}"
   }
 
-  # TODO: port null_resource.worker_com_validation to instance group
+  depends_on = ["null_resource.worker_com_free_validation"]
 
   lifecycle {
     create_before_destroy = true
@@ -454,7 +454,7 @@ resource "google_compute_instance_template" "worker_org" {
     "user-data"              = "${data.template_file.cloud_config_org.rendered}"
   }
 
-  # TODO: port null_resource.worker_org_validation to instance group
+  depends_on = ["null_resource.worker_org_validation"]
 
   lifecycle {
     create_before_destroy = true

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -48,6 +48,18 @@ variable "worker_instance_count_com" {}
 variable "worker_instance_count_com_free" {}
 variable "worker_instance_count_org" {}
 
+variable "worker_managed_instance_count_com" {
+  default = 0
+}
+
+variable "worker_managed_instance_count_com_free" {
+  default = 0
+}
+
+variable "worker_managed_instance_count_org" {
+  default = 0
+}
+
 variable "worker_machine_type" {
   default = "g1-small"
 }
@@ -61,15 +73,21 @@ variable "worker_zones" {
 module "gce_workers" {
   source = "../gce_worker"
 
-  config_com               = "${var.worker_config_com}"
-  config_com_free          = "${var.worker_config_com_free}"
-  config_org               = "${var.worker_config_org}"
-  env                      = "${var.env}"
-  github_users             = "${var.github_users}"
-  index                    = "${var.index}"
-  instance_count_com       = "${var.worker_instance_count_com}"
-  instance_count_com_free  = "${var.worker_instance_count_com_free}"
-  instance_count_org       = "${var.worker_instance_count_org}"
+  config_com      = "${var.worker_config_com}"
+  config_com_free = "${var.worker_config_com_free}"
+  config_org      = "${var.worker_config_org}"
+  env             = "${var.env}"
+  github_users    = "${var.github_users}"
+  index           = "${var.index}"
+
+  instance_count_com      = "${var.worker_instance_count_com}"
+  instance_count_com_free = "${var.worker_instance_count_com_free}"
+  instance_count_org      = "${var.worker_instance_count_org}"
+
+  managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
+  managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
+  managed_instance_count_org      = "${var.worker_managed_instance_count_org}"
+
   machine_type             = "${var.worker_machine_type}"
   project                  = "${var.project}"
   region                   = "${var.region}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Currently there is no managed way to cycle GCE worker instances. While we still need to figure out how to do graceful shutdowns, instance groups might make it more straight forward to roll out new worker versions and configs on GCE.

We'll need to migrate the traffic over to these worker instances before we shut down the old ones.

## What approach did you choose and why?

Instance groups, managed by google cloud.

## How can you test this?

We can apply it on staging and make sure the workers come up successfully.

## What feedback would you like, if any?

What do y'all think about this approach?

refs https://github.com/travis-ci/reliability/issues/112
refs https://github.com/travis-ci/terraform-config/issues/347