### PR TITLE
terraform-managed s3 credentials for the build tracing

### DIFF
--- a/.example-aws-iam-policy.json
+++ b/.example-aws-iam-policy.json
@@ -25,6 +25,8 @@
                 "arn:aws:s3:::travis-terraform-state/*",
                 "arn:aws:s3:::travis-shared-1-registry-images",
                 "arn:aws:s3:::travis-shared-1-registry-images/*"
+                "arn:aws:s3:::travis-shared-2-registry-images",
+                "arn:aws:s3:::travis-shared-2-registry-images/*"
             ]
         },
         {
@@ -44,8 +46,10 @@
             "Resource": [
                 "arn:aws:iam::341288657826:role/*",
                 "arn:aws:iam::341288657826:user/registry-shared-1",
+                "arn:aws:iam::341288657826:user/registry-shared-2",
                 "arn:aws:iam::*:user/cyclist-*",
-                "arn:aws:iam::*:user/worker-*"
+                "arn:aws:iam::*:user/worker-*",
+                "arn:aws:iam::*:user/build-trace-*"
             ]
         },
         {

--- a/aws-shared-1/main.tf
+++ b/aws-shared-1/main.tf
@@ -258,6 +258,18 @@ resource "aws_route_table_association" "packer_build" {
   route_table_id = "${aws_route_table.packer_build.id}"
 }
 
+module "aws_iam_user_s3_com" {
+  source         = "../modules/aws_iam_user_s3"
+  iam_user_name  = "build-trace-${var.env}-${var.index}-com"
+  s3_bucket_name = "build-trace-staging.travis-ci.com"
+}
+
+module "aws_iam_user_s3_org" {
+  source         = "../modules/aws_iam_user_s3"
+  iam_user_name  = "build-trace-${var.env}-${var.index}-org"
+  s3_bucket_name = "build-trace-staging.travis-ci.org"
+}
+
 module "aws_bastion_1b" {
   source                        = "../modules/aws_bastion"
   az                            = "1b"
@@ -458,4 +470,20 @@ output "workers_org_subnet_1b_id" {
 
 output "workers_org_subnet_1b2_id" {
   value = "${module.aws_az_1b2.workers_org_subnet_id}"
+}
+
+output "shared_build_tracing_s3_user_com_id" {
+  value = "${module.aws_iam_user_s3_com.id}"
+}
+
+output "shared_build_tracing_s3_user_com_secret" {
+  value = "${module.aws_iam_user_s3_com.secret}"
+}
+
+output "shared_build_tracing_s3_user_org_id" {
+  value = "${module.aws_iam_user_s3_org.id}"
+}
+
+output "shared_build_tracing_s3_user_org_secret" {
+  value = "${module.aws_iam_user_s3_org.secret}"
 }

--- a/aws-shared-2/main.tf
+++ b/aws-shared-2/main.tf
@@ -262,6 +262,18 @@ resource "aws_vpc_endpoint" "s3" {
 EOF
 }
 
+module "aws_iam_user_s3_com" {
+  source         = "../modules/aws_iam_user_s3"
+  iam_user_name  = "build-trace-${var.env}-${var.index}-com"
+  s3_bucket_name = "build-trace.travis-ci.com"
+}
+
+module "aws_iam_user_s3_org" {
+  source         = "../modules/aws_iam_user_s3"
+  iam_user_name  = "build-trace-${var.env}-${var.index}-org"
+  s3_bucket_name = "build-trace.travis-ci.org"
+}
+
 module "aws_bastion_1b" {
   source                        = "../modules/aws_bastion"
   az                            = "1b"
@@ -581,4 +593,20 @@ output "workers_org_subnet_1e2_cidr" {
 
 output "workers_org_subnet_1e2_id" {
   value = "${module.aws_az_1e2.workers_org_subnet_id}"
+}
+
+output "shared_build_tracing_s3_user_com_id" {
+  value = "${module.aws_iam_user_s3_com.id}"
+}
+
+output "shared_build_tracing_s3_user_com_secret" {
+  value = "${module.aws_iam_user_s3_com.secret}"
+}
+
+output "shared_build_tracing_s3_user_org_id" {
+  value = "${module.aws_iam_user_s3_org.id}"
+}
+
+output "shared_build_tracing_s3_user_org_secret" {
+  value = "${module.aws_iam_user_s3_org.secret}"
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Manage S3 credentials for our build tracing related heroku apps, mostly traceproc.

refs https://github.com/travis-ci/reliability/issues/165