### PR TITLE
Deploy macbot with Docker Swarm

### DIFF
--- a/macstadium-pod-1/Makefile
+++ b/macstadium-pod-1/Makefile
@@ -29,7 +29,8 @@ CONFIG_FILES := \
 		config/jupiter-brain-staging-com-env \
 		config/vsphere-monitor \
 		config/collectd-vsphere-common \
-		config/image-builder \
+		config/image-builder-packer-env \
+		config/image-builder-macbot-env \
 		config/travis-vm-ssh-key
 
 INDEX ?= $(subst $(INFRA)-$(ENV_SHORT)-,,$(ENV_NAME))
@@ -66,8 +67,10 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/travis-worker-staging-com-common
 	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-common \
 		| sed 's/^/export /' >config/travis-worker-production-com-common
-	trvs generate-config -n --env-prefix= -f env macstadium-image-builder image-builder \
-		| sed 's/^/export /' >config/image-builder
+	trvs generate-config -n --env-prefix= -f env macstadium-image-builder packer \
+		| sed 's/^/export /' >config/image-builder-packer-env
+	trvs generate-config -n --env-prefix= -f env macstadium-image-builder macbot \
+		| sed 's/\\!/!/' >config/image-builder-macbot-env
 	\
 	trvs generate-config --pro -p VSPHERE_JANITOR -f env vsphere-janitor production-$(INDEX) \
 		| sed 's/^/export /' >config/vsphere-janitor-production-com

--- a/macstadium-pod-1/install-macbot.sh
+++ b/macstadium-pod-1/install-macbot.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit
+
+main() {
+  create_docker_swarm
+  move_files
+  deploy_macbot_stack
+}
+
+create_docker_swarm() {
+  echo ">>> Creating Docker Swarm if needed"
+  docker swarm init >/dev/null 2>&1 || { echo "Docker swarm already exists."; }
+}
+
+move_files() {
+  echo ">>> Moving service files into place"
+  mv /tmp/macbot-env /home/packer/.macbot-env
+  mv /tmp/macbot.yml /home/packer/macbot.yml
+  chown packer:packer /home/packer/*
+}
+
+deploy_macbot_stack() {
+  echo ">>> Deploying macbot"
+
+  docker pull travisci/macbot:latest
+  docker stack deploy -c /home/packer/macbot.yml macbot
+}
+
+main "$@"

--- a/macstadium-pod-1/macbot.yml
+++ b/macstadium-pod-1/macbot.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  macbot:
+    image: travisci/macbot:latest
+    env_file: .macbot-env
+    networks:
+    - net
+networks:
+  net:

--- a/macstadium-pod-1/main.tf
+++ b/macstadium-pod-1/main.tf
@@ -423,7 +423,7 @@ resource "null_resource" "image-builder-macbot" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/install-macbot.sh",
-      "sudo /tmp/install-macbot.sh"
+      "sudo /tmp/install-macbot.sh",
     ]
   }
 }

--- a/macstadium-pod-1/main.tf
+++ b/macstadium-pod-1/main.tf
@@ -325,8 +325,8 @@ data "template_file" "build_macos_script" {
   template = "${file("build-macos.sh")}"
 }
 
-data "template_file" "image_builder_env" {
-  template = "${file("config/image-builder")}"
+data "template_file" "image_builder_packer_env" {
+  template = "${file("config/image-builder-packer-env")}"
 }
 
 resource "null_resource" "image-builder-environment" {
@@ -334,7 +334,7 @@ resource "null_resource" "image-builder-environment" {
     host_id                  = "${vsphere_virtual_machine.image-builder.uuid}"
     install_script_signature = "${sha256(data.template_file.image_builder_installer.rendered)}"
     run_script_signature     = "${sha256(data.template_file.build_macos_script.rendered)}"
-    env_signature            = "${sha256(data.template_file.image_builder_env.rendered)}"
+    packer_env_signature     = "${sha256(data.template_file.image_builder_packer_env.rendered)}"
   }
 
   connection {
@@ -361,7 +361,7 @@ resource "null_resource" "image-builder-environment" {
   }
 
   provisioner "file" {
-    content     = "${data.template_file.image_builder_env.rendered}"
+    content     = "${data.template_file.image_builder_packer_env.rendered}"
     destination = "/tmp/packer-env"
   }
 
@@ -372,6 +372,58 @@ resource "null_resource" "image-builder-environment" {
       "sudo chmod +x /home/packer/bin/build-macos",
       "sudo mv /tmp/packer-env /home/packer/.packer-env",
       "sudo chown packer:packer /home/packer/.packer-env",
+    ]
+  }
+}
+
+data "template_file" "image_builder_macbot_env" {
+  template = "${file("config/image-builder-macbot-env")}"
+}
+
+data "template_file" "image_builder_macbot_service" {
+  template = "${file("macbot.yml")}"
+}
+
+data "template_file" "image_builder_macbot_installer" {
+  template = "${file("install-macbot.sh")}"
+}
+
+resource "null_resource" "image-builder-macbot" {
+  // This depends on the packer user existing and on Docker being installed
+  depends_on = ["null_resource.image-builder-environment"]
+
+  triggers {
+    host_id             = "${vsphere_virtual_machine.image-builder.uuid}"
+    installer_signature = "${sha256(data.template_file.image_builder_macbot_installer.rendered)}"
+    env_signature       = "${sha256(data.template_file.image_builder_macbot_env.rendered)}"
+    service_signature   = "${sha256(data.template_file.image_builder_macbot_service.rendered)}"
+  }
+
+  connection {
+    host  = "${vsphere_virtual_machine.image-builder.network_interface.0.ipv4_address}"
+    user  = "${var.ssh_user}"
+    agent = true
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.image_builder_macbot_env.rendered}"
+    destination = "/tmp/macbot-env"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.image_builder_macbot_service.rendered}"
+    destination = "/tmp/macbot.yml"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.image_builder_macbot_installer.rendered}"
+    destination = "/tmp/install-macbot.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/install-macbot.sh",
+      "sudo /tmp/install-macbot.sh"
     ]
   }
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

macbot is currently deployed to the image-builder by hand, when it should be handled in our Terraform config so it can be reproduced from scratch.

## What approach did you choose and why?

Added a new null resource after the existing image-builder environment resource, which is responsible for deploying macbot. This resource sets up a single-machine Docker Swarm on image-builder and deploys a very basic stack for now using the latest macbot docker image. This is what I had already done manually, so now it just makes that setup automated.

It may seem weird that this uses shell commands when really Terraform should have support for doing Docker things. However, their support for Docker Swarm is really immature even in current versions of Terraform, so most people seem to use something like Ansible with Terraform for this. However, Ansible only has modules for Docker Swarm in the development version 2.7, and we don't have existing setups for using Ansible with our Terraform (although I'd like to move in that direction at some point).

## How can you test this?

I had tested this approach by hand first after we had Docker set up on the machine. I've also applied these changes and verified that they set everything up correctly. Starting from nothing, applying these changes causes macbot to be deployed as a Docker service which is immediately available in Slack, and it appears to successfully connect to vSphere.

## What feedback would you like, if any?

Any.