### PR TITLE
gce-production: roll out managed instance group

### DIFF
--- a/gce-production-1/instance-counts.auto.tfvars
+++ b/gce-production-1/instance-counts.auto.tfvars
@@ -2,7 +2,7 @@
   "worker_instance_count_com": 18,
   "worker_instance_count_org": 21,
   "worker_instance_count_com_free": 1,
-  "worker_managed_instance_count_com": 0,
-  "worker_managed_instance_count_org": 0,
+  "worker_managed_instance_count_com": 1,
+  "worker_managed_instance_count_org": 1,
   "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-1/instance-counts.auto.tfvars
+++ b/gce-production-1/instance-counts.auto.tfvars
@@ -1,5 +1,8 @@
 {
   "worker_instance_count_com": 18,
   "worker_instance_count_org": 21,
-  "worker_instance_count_com_free": 1
+  "worker_instance_count_com_free": 1,
+  "worker_managed_instance_count_com": 0,
+  "worker_managed_instance_count_org": 0,
+  "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -32,6 +32,10 @@ variable "worker_instance_count_com" {}
 variable "worker_instance_count_org" {}
 variable "worker_instance_count_com_free" {}
 
+variable "worker_managed_instance_count_com" {}
+variable "worker_managed_instance_count_org" {}
+variable "worker_managed_instance_count_com_free" {}
+
 variable "worker_zones" {
   default = ["a", "b", "f"]
 }
@@ -156,6 +160,10 @@ module "gce_worker_group" {
   worker_instance_count_com      = "${var.worker_instance_count_com}"
   worker_instance_count_com_free = "${var.worker_instance_count_com_free}"
   worker_instance_count_org      = "${var.worker_instance_count_org}"
+
+  worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
+  worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
+  worker_managed_instance_count_org      = "${var.worker_managed_instance_count_org}"
 
   worker_config_com = <<EOF
 ### worker.env

--- a/gce-production-2/instance-counts.auto.tfvars
+++ b/gce-production-2/instance-counts.auto.tfvars
@@ -1,4 +1,8 @@
 {
   "worker_instance_count_com": 3,
-  "worker_instance_count_org": 3
+  "worker_instance_count_org": 3,
+  "worker_instance_count_com_free": 0,
+  "worker_managed_instance_count_com": 3,
+  "worker_managed_instance_count_org": 3,
+  "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-2/instance-counts.auto.tfvars
+++ b/gce-production-2/instance-counts.auto.tfvars
@@ -2,7 +2,7 @@
   "worker_instance_count_com": 3,
   "worker_instance_count_org": 3,
   "worker_instance_count_com_free": 0,
-  "worker_managed_instance_count_com": 3,
-  "worker_managed_instance_count_org": 3,
+  "worker_managed_instance_count_com": 1,
+  "worker_managed_instance_count_org": 1,
   "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -30,10 +30,11 @@ variable "travisci_net_external_zone_id" {
 
 variable "worker_instance_count_com" {}
 variable "worker_instance_count_org" {}
+variable "worker_instance_count_com_free" {}
 
-variable "worker_instance_count_com_free" {
-  default = "0"
-}
+variable "worker_managed_instance_count_com" {}
+variable "worker_managed_instance_count_org" {}
+variable "worker_managed_instance_count_com_free" {}
 
 variable "worker_zones" {
   default = ["a", "b", "f"]
@@ -104,6 +105,10 @@ module "gce_worker_group" {
   worker_instance_count_com      = "${var.worker_instance_count_com}"
   worker_instance_count_com_free = "${var.worker_instance_count_com_free}"
   worker_instance_count_org      = "${var.worker_instance_count_org}"
+
+  worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
+  worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
+  worker_managed_instance_count_org      = "${var.worker_managed_instance_count_org}"
 
   worker_config_com = <<EOF
 ### worker.env


### PR DESCRIPTION
This is the first step in rolling out managed instance groups for gce. We are targeting gce prod-1 and prod-2, since we want to balance the number of workers between those two projects.

refs https://github.com/travis-ci/reliability/issues/162, https://github.com/travis-ci/reliability/issues/163