### PR TITLE
production-1: update NAT size to n1-standard-4

### DIFF
--- a/gce-production-net-1/main.tf
+++ b/gce-production-net-1/main.tf
@@ -78,6 +78,7 @@ module "gce_net" {
   nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
   nat_count_per_zone            = 2
   nat_image                     = "${var.gce_nat_image}"
+  nat_machine_type              = "n1-standard-4"
   project                       = "${var.project}"
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"
   syslog_address                = "${var.syslog_address_com}"


### PR DESCRIPTION
We get 2 Gbps per core. So this should take us from 250 MBps per NAT to 1 GBps per NAT.

This is a port of https://github.com/travis-ci/terraform-config/pull/555 to production-1.