### PR TITLE
Added manage-workers script to Mac wjb VMs

### DIFF
--- a/modules/macstadium_infrastructure/manage-workers.sh
+++ b/modules/macstadium_infrastructure/manage-workers.sh
@@ -5,76 +5,77 @@ com_instances=$(echo production-com-{1..4})
 instances="$org_instances $com_instances"
 
 worker_http_auth() {
-  local instance="$1"
-  grep HTTP_API_AUTH "/etc/default/travis-worker-${instance}" | cut -d\" -f 2
+	local instance="$1"
+	grep HTTP_API_AUTH "/etc/default/travis-worker-${instance}" | cut -d\" -f 2
 }
 
 worker_http_port() {
-  local instance="$1"
-  grep PPROF_PORT "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
+	local instance="$1"
+	grep PPROF_PORT "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
 }
 
 current_pool_size() {
-  local port="$1"
-  local auth="$2"
-  curl -XPOST "http://$auth@localhost:$port/worker/info" 2>/dev/null | grep 'pool_size' | tr -dc '0-9'
+	local port="$1"
+	local auth="$2"
+	curl -XPOST "http://$auth@localhost:$port/worker/info" 2>/dev/null | grep 'pool_size' | tr -dc '0-9'
 }
 
 desired_pool_size() {
-  local instance="$1"
-  grep POOL_SIZE "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
+	local instance="$1"
+	grep POOL_SIZE "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
 }
 
 adjust_pool_size() {
-  local inst="$1"
-  local port
-  local auth
-  local cur_pool_size
-  local des_pool_size
-  port=$(worker_http_port "$inst")
-  auth=$(worker_http_auth "$inst")
-  echo "Adjusting pool size for travis-worker-$inst"
+	local inst="$1"
+	local port
+	local auth
+	local cur_pool_size
+	local des_pool_size
+	port=$(worker_http_port "$inst")
+	auth=$(worker_http_auth "$inst")
+	echo "Adjusting pool size for travis-worker-$inst"
 
-  cur_pool_size=$(current_pool_size "$port" "$auth")
-  des_pool_size=$(desired_pool_size "$inst")
-  echo "  Current: $cur_pool_size"
-  echo "  Desired: $des_pool_size"
+	cur_pool_size=$(current_pool_size "$port" "$auth")
+	des_pool_size=$(desired_pool_size "$inst")
+	echo "  Current: $cur_pool_size"
+	echo "  Desired: $des_pool_size"
 
-  local diff=$((des_pool_size - cur_pool_size))
-  echo "  Diff: $diff"
+	local diff=$((des_pool_size - cur_pool_size))
+	echo "  Diff: $diff"
 
-  if [[ $diff -eq 0 ]]; then
-    echo "No changes needed."
-  elif [[ $diff -gt 0 ]]; then
-    echo "Adding $diff processors to the pool."
-    for ((i=0;i < diff;i++)); do
-      curl -XPOST "http://$auth@localhost:$port/worker/pool-incr" 2>/dev/null
-      sleep 1
-    done
-  else
-    num=${diff#-}
-    echo "Removing $num processors from the pool."
-    for ((i=0;i < num;i++)); do
-      curl -XPOST "http://$auth@localhost:$port/worker/pool-decr" 2>/dev/null
-      sleep 1
-    done
-  fi
+	if [[ $diff -eq 0 ]]; then
+		echo "No changes needed."
+	elif [[ $diff -gt 0 ]]; then
+		echo "Adding $diff processors to the pool."
+		for ((i = 0; i < diff; i++)); do
+			curl -XPOST "http://$auth@localhost:$port/worker/pool-incr" 2>/dev/null
+			sleep 1
+		done
+	else
+		num=${diff#-}
+		echo "Removing $num processors from the pool."
+		for ((i = 0; i < num; i++)); do
+			curl -XPOST "http://$auth@localhost:$port/worker/pool-decr" 2>/dev/null
+			sleep 1
+		done
+	fi
 
-  echo
+	echo
 }
 
 reset_pool_sizes() {
-  for inst in $instances; do
-    adjust_pool_size "$inst"
-  done
+	for inst in $instances; do
+		adjust_pool_size "$inst"
+	done
 }
 
 case "$1" in
-  reset-pools)
-    reset_pool_sizes
-    ;;
+reset-pools)
+	reset_pool_sizes
+	;;
 
-  *)
-    echo $"Usage: $0 {reset-pools|help}"
-    exit 1
+*)
+	echo $"Usage: $0 {reset-pools|help}"
+	exit 1
+	;;
 esac

--- a/modules/macstadium_infrastructure/manage-workers.sh
+++ b/modules/macstadium_infrastructure/manage-workers.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+org_instances=$(echo production-org-{1..4})
+com_instances=$(echo production-com-{1..4})
+instances="$org_instances $com_instances"
+
+worker_http_auth() {
+  local instance="$1"
+  grep HTTP_API_AUTH "/etc/default/travis-worker-${instance}" | cut -d\" -f 2
+}
+
+worker_http_port() {
+  local instance="$1"
+  grep PPROF_PORT "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
+}
+
+current_pool_size() {
+  local port="$1"
+  local auth="$2"
+  curl -XPOST "http://$auth@localhost:$port/worker/info" 2>/dev/null | grep 'pool_size' | tr -dc '0-9'
+}
+
+desired_pool_size() {
+  local instance="$1"
+  grep POOL_SIZE "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
+}
+
+adjust_pool_size() {
+  local inst="$1"
+  local port
+  local auth
+  local cur_pool_size
+  local des_pool_size
+  port=$(worker_http_port "$inst")
+  auth=$(worker_http_auth "$inst")
+  echo "Adjusting pool size for travis-worker-$inst"
+
+  cur_pool_size=$(current_pool_size "$port" "$auth")
+  des_pool_size=$(desired_pool_size "$inst")
+  echo "  Current: $cur_pool_size"
+  echo "  Desired: $des_pool_size"
+
+  local diff=$((des_pool_size - cur_pool_size))
+  echo "  Diff: $diff"
+
+  if [[ $diff -eq 0 ]]; then
+    echo "No changes needed."
+  elif [[ $diff -gt 0 ]]; then
+    echo "Adding $diff processors to the pool."
+    for ((i=0;i < diff;i++)); do
+      curl -XPOST "http://$auth@localhost:$port/worker/pool-incr" 2>/dev/null
+      sleep 1
+    done
+  else
+    num=${diff#-}
+    echo "Removing $num processors from the pool."
+    for ((i=0;i < num;i++)); do
+      curl -XPOST "http://$auth@localhost:$port/worker/pool-decr" 2>/dev/null
+      sleep 1
+    done
+  fi
+
+  echo
+}
+
+reset_pool_sizes() {
+  for inst in $instances; do
+    adjust_pool_size "$inst"
+  done
+}
+
+case "$1" in
+  reset-pools)
+    reset_pool_sizes
+    ;;
+
+  *)
+    echo $"Usage: $0 {reset-pools|help}"
+    exit 1
+esac

--- a/modules/macstadium_infrastructure/manage-workers.sh
+++ b/modules/macstadium_infrastructure/manage-workers.sh
@@ -5,77 +5,77 @@ com_instances=$(echo production-com-{1..4})
 instances="$org_instances $com_instances"
 
 worker_http_auth() {
-	local instance="$1"
-	grep HTTP_API_AUTH "/etc/default/travis-worker-${instance}" | cut -d\" -f 2
+  local instance="$1"
+  grep HTTP_API_AUTH "/etc/default/travis-worker-${instance}" | cut -d\" -f 2
 }
 
 worker_http_port() {
-	local instance="$1"
-	grep PPROF_PORT "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
+  local instance="$1"
+  grep PPROF_PORT "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
 }
 
 current_pool_size() {
-	local port="$1"
-	local auth="$2"
-	curl -XPOST "http://$auth@localhost:$port/worker/info" 2>/dev/null | grep 'pool_size' | tr -dc '0-9'
+  local port="$1"
+  local auth="$2"
+  curl -XPOST "http://$auth@localhost:$port/worker/info" 2>/dev/null | grep 'pool_size' | tr -dc '0-9'
 }
 
 desired_pool_size() {
-	local instance="$1"
-	grep POOL_SIZE "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
+  local instance="$1"
+  grep POOL_SIZE "/etc/default/travis-worker-${instance}" | tr -dc '0-9'
 }
 
 adjust_pool_size() {
-	local inst="$1"
-	local port
-	local auth
-	local cur_pool_size
-	local des_pool_size
-	port=$(worker_http_port "$inst")
-	auth=$(worker_http_auth "$inst")
-	echo "Adjusting pool size for travis-worker-$inst"
+  local inst="$1"
+  local port
+  local auth
+  local cur_pool_size
+  local des_pool_size
+  port=$(worker_http_port "$inst")
+  auth=$(worker_http_auth "$inst")
+  echo "Adjusting pool size for travis-worker-$inst"
 
-	cur_pool_size=$(current_pool_size "$port" "$auth")
-	des_pool_size=$(desired_pool_size "$inst")
-	echo "  Current: $cur_pool_size"
-	echo "  Desired: $des_pool_size"
+  cur_pool_size=$(current_pool_size "$port" "$auth")
+  des_pool_size=$(desired_pool_size "$inst")
+  echo "  Current: $cur_pool_size"
+  echo "  Desired: $des_pool_size"
 
-	local diff=$((des_pool_size - cur_pool_size))
-	echo "  Diff: $diff"
+  local diff=$((des_pool_size - cur_pool_size))
+  echo "  Diff: $diff"
 
-	if [[ $diff -eq 0 ]]; then
-		echo "No changes needed."
-	elif [[ $diff -gt 0 ]]; then
-		echo "Adding $diff processors to the pool."
-		for ((i = 0; i < diff; i++)); do
-			curl -XPOST "http://$auth@localhost:$port/worker/pool-incr" 2>/dev/null
-			sleep 1
-		done
-	else
-		num=${diff#-}
-		echo "Removing $num processors from the pool."
-		for ((i = 0; i < num; i++)); do
-			curl -XPOST "http://$auth@localhost:$port/worker/pool-decr" 2>/dev/null
-			sleep 1
-		done
-	fi
+  if [[ $diff -eq 0 ]]; then
+    echo "No changes needed."
+  elif [[ $diff -gt 0 ]]; then
+    echo "Adding $diff processors to the pool."
+    for ((i = 0; i < diff; i++)); do
+      curl -XPOST "http://$auth@localhost:$port/worker/pool-incr" 2>/dev/null
+      sleep 1
+    done
+  else
+    num=${diff#-}
+    echo "Removing $num processors from the pool."
+    for ((i = 0; i < num; i++)); do
+      curl -XPOST "http://$auth@localhost:$port/worker/pool-decr" 2>/dev/null
+      sleep 1
+    done
+  fi
 
-	echo
+  echo
 }
 
 reset_pool_sizes() {
-	for inst in $instances; do
-		adjust_pool_size "$inst"
-	done
+  for inst in $instances; do
+    adjust_pool_size "$inst"
+  done
 }
 
 case "$1" in
 reset-pools)
-	reset_pool_sizes
-	;;
+  reset_pool_sizes
+  ;;
 
 *)
-	echo $"Usage: $0 {reset-pools|help}"
-	exit 1
-	;;
+  echo $"Usage: $0 {reset-pools|help}"
+  exit 1
+  ;;
 esac


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We want to be able to easily adjust worker pool sizes with minimal disruption to existing jobs.

## What approach did you choose and why?

Previously, I deployed changes to enable the local HTTP API for worker. That was to enable this script, which uses that API to check the current pool size of each worker, compare it to the configured pool size on disk, and then make API calls to incr/decr the pool size until it matches.

This means if we want to change the pool size for workers, all we have to do is make the Terraform changes, apply them, then log in to wjb-1/2 and run `sudo manage-workers reset-pools`.

Eventually, we may give this script more responsibilities but this is a good start.

## How can you test this?

I've run the script on the machines to make changes to pool sizes last week. It works great!

## What feedback would you like, if any?

Any!