### PR TITLE
gce-production: increase gcloud cleanup loop sleep from 1s to 1m

### DIFF
--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -15,7 +15,7 @@ variable "gcloud_cleanup_instance_max_age" {
 variable "gcloud_cleanup_job_board_url" {}
 
 variable "gcloud_cleanup_loop_sleep" {
-  default = "1s"
+  default = "1m"
 }
 
 variable "gcloud_cleanup_opencensus_sampling_rate" {}


### PR DESCRIPTION
Since https://github.com/travis-ci/gcloud-cleanup/pull/43 make gcloud-cleanup a lot faster, we now do not need to run it as frequently. We can drop down to a run once per minute in production.

refs https://github.com/travis-ci/reliability/issues/148