### PR TITLE
Set com pool GCE disk to 50GB

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -140,9 +140,10 @@ ${file("${path.module}/worker.env")}
 ### config/worker-com.env
 ${file("${path.module}/config/worker-com.env")}
 
-export TRAVIS_WORKER_QUEUE_NAME=builds.gce
+export TRAVIS_WORKER_GCE_DISK_SIZE=50
 export TRAVIS_WORKER_GCE_SUBNETWORK=jobs-com
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
+export TRAVIS_WORKER_QUEUE_NAME=builds.gce
 export TRAVIS_WORKER_TRAVIS_SITE=com
 
 export TRAVIS_WORKER_BUILD_TRACE_S3_BUCKET=${module.aws_iam_user_s3_com.bucket}

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -118,9 +118,10 @@ ${file("${path.module}/worker.env")}
 ### config/worker-com.env
 ${file("${path.module}/config/worker-com.env")}
 
-export TRAVIS_WORKER_QUEUE_NAME=builds.gce
+export TRAVIS_WORKER_GCE_DISK_SIZE=50
 export TRAVIS_WORKER_GCE_SUBNETWORK=jobs-com
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
+export TRAVIS_WORKER_QUEUE_NAME=builds.gce
 export TRAVIS_WORKER_TRAVIS_SITE=com
 
 export TRAVIS_WORKER_BUILD_TRACE_S3_BUCKET=${module.aws_iam_user_s3_com.bucket}


### PR DESCRIPTION
to ensure compatibility with Windows bits.

Without this change, jobs refuse to start, showing error in logs:

```
googleapi: Error 400: Invalid value for field 'resource.disks[0].initializeParams.diskSizeGb': '30'. Requested disk size cannot be smaller than the image size (50 GB), invalid
```