### PR TITLE
Switch MacStadium to use CloudFlare DNS

### DIFF
--- a/modules/macstadium_dhcp_server/dhcpd.conf.tpl
+++ b/modules/macstadium_dhcp_server/dhcpd.conf.tpl
@@ -2,7 +2,7 @@ subnet ${jobs_subnet} netmask ${jobs_subnet_netmask} {
   option domain-name "${domain_name}";
   range ${jobs_subnet_begin} ${jobs_subnet_end};
   option routers ${jobs_gateway};
-  option domain-name-servers 8.8.8.8, 8.8.4.4;
+  option domain-name-servers 1.1.1.1, 1.0.0.1;
   default-lease-time ${dhcp_lease_default_time};
   max-lease-time ${dhcp_lease_max_time};
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Google's Public DNS has been acting up for us in the MacStadium infrastructure, giving 5n second delays on some DNS queries. @joepvd verified this with isolated nslookups on wjb-1. It seems like this is something weird about our network.

## What approach did you choose and why?

Switch to CloudFlare's 1.1.1.1 DNS. It's faster in general than Google's and it does not seem to produce these delays in our testing.

## How can you test this?

We've run nslookup tests on the machines in our infra. Otherwise, we just need to deploy and monitor.

## What feedback would you like, if any?

Any.