### PR TITLE
remove public network interface on warmer pool instances

### DIFF
--- a/modules/gce_warmer/main.tf
+++ b/modules/gce_warmer/main.tf
@@ -49,10 +49,6 @@ resource "google_compute_instance_template" "warmer_pool_org" {
 
   network_interface {
     subnetwork = "jobs-org"
-
-    access_config {
-      # ephemeral ip
-    }
   }
 
   metadata {

--- a/modules/gce_warmer/main.tf
+++ b/modules/gce_warmer/main.tf
@@ -54,6 +54,10 @@ resource "google_compute_instance_template" "warmer_pool_org" {
   metadata {
     "block-project-ssh-keys" = "true"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_region_instance_group_manager" "warmer_pool_org" {


### PR DESCRIPTION
Worker creates job VMs without a public IP, so that all traffic goes through the NAT. This change ensures pre-warmed instances have the same behaviour.

refs travis-ci/reliability#195