### PR TITLE
gce-staging-1: remove currently unused instance from com-free pool

### DIFF
--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -105,7 +105,7 @@ module "gce_worker_group" {
   worker_instance_count_org      = "0"
 
   worker_managed_instance_count_com      = "${length(var.worker_zones)}"
-  worker_managed_instance_count_com_free = "1"
+  worker_managed_instance_count_com_free = "0"
   worker_managed_instance_count_org      = "${length(var.worker_zones)}"
 
   worker_config_com = <<EOF


### PR DESCRIPTION
The `com-free` pool is currently not in use. AFAIK the code in scheduler to direct jobs there does not exist yet. So I think it makes sense to turn this instance off for now.