### PR TITLE
retire workers that are not part of a managed instance group

### DIFF
--- a/gce-production-1/instance-counts.auto.tfvars
+++ b/gce-production-1/instance-counts.auto.tfvars
@@ -1,7 +1,4 @@
 {
-  "worker_instance_count_com": 0,
-  "worker_instance_count_org": 0,
-  "worker_instance_count_com_free": 0,
   "worker_managed_instance_count_com": 27,
   "worker_managed_instance_count_org": 33,
   "worker_managed_instance_count_com_free": 0

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -28,10 +28,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "worker_instance_count_com" {}
-variable "worker_instance_count_org" {}
-variable "worker_instance_count_com_free" {}
-
 variable "worker_managed_instance_count_com" {}
 variable "worker_managed_instance_count_org" {}
 variable "worker_managed_instance_count_com_free" {}
@@ -125,10 +121,6 @@ module "gce_worker_group" {
   worker_subnetwork                         = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_zones = "${var.worker_zones}"
-
-  worker_instance_count_com      = "${var.worker_instance_count_com}"
-  worker_instance_count_com_free = "${var.worker_instance_count_com_free}"
-  worker_instance_count_org      = "${var.worker_instance_count_org}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/gce-production-2/instance-counts.auto.tfvars
+++ b/gce-production-2/instance-counts.auto.tfvars
@@ -1,7 +1,4 @@
 {
-  "worker_instance_count_com": 0,
-  "worker_instance_count_org": 0,
-  "worker_instance_count_com_free": 0,
   "worker_managed_instance_count_com": 27,
   "worker_managed_instance_count_org": 33,
   "worker_managed_instance_count_com_free": 0

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -28,10 +28,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "worker_instance_count_com" {}
-variable "worker_instance_count_org" {}
-variable "worker_instance_count_com_free" {}
-
 variable "worker_managed_instance_count_com" {}
 variable "worker_managed_instance_count_org" {}
 variable "worker_managed_instance_count_com_free" {}
@@ -103,10 +99,6 @@ module "gce_worker_group" {
   worker_subnetwork                         = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_zones = "${var.worker_zones}"
-
-  worker_instance_count_com      = "${var.worker_instance_count_com}"
-  worker_instance_count_com_free = "${var.worker_instance_count_com_free}"
-  worker_instance_count_org      = "${var.worker_instance_count_org}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/gce-production-3/instance-counts.auto.tfvars
+++ b/gce-production-3/instance-counts.auto.tfvars
@@ -1,4 +1,2 @@
 {
-  "worker_instance_count_com": 0,
-  "worker_instance_count_org": 0
 }

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -28,13 +28,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "worker_instance_count_com" {}
-variable "worker_instance_count_org" {}
-
-variable "worker_instance_count_com_free" {
-  default = "0"
-}
-
 variable "worker_zones" {
   default = ["a", "b", "f"]
 }

--- a/gce-production-4/instance-counts.auto.tfvars
+++ b/gce-production-4/instance-counts.auto.tfvars
@@ -1,4 +1,2 @@
 {
-  "worker_instance_count_com": 0,
-  "worker_instance_count_org": 0
 }

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -28,13 +28,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "worker_instance_count_com" {}
-variable "worker_instance_count_org" {}
-
-variable "worker_instance_count_com_free" {
-  default = "0"
-}
-
 variable "worker_zones" {
   default = ["a", "b", "f"]
 }

--- a/gce-production-5/instance-counts.auto.tfvars
+++ b/gce-production-5/instance-counts.auto.tfvars
@@ -1,4 +1,2 @@
 {
-  "worker_instance_count_com": 0,
-  "worker_instance_count_org": 0
 }

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -27,12 +27,6 @@ variable "travisci_net_external_zone_id" {
 
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
-variable "worker_instance_count_com" {}
-variable "worker_instance_count_org" {}
-
-variable "worker_instance_count_com_free" {
-  default = "0"
-}
 
 variable "worker_zones" {
   default = ["a", "b", "f"]

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -100,10 +100,6 @@ module "gce_worker_group" {
 
   worker_zones = "${var.worker_zones}"
 
-  worker_instance_count_com      = "0"
-  worker_instance_count_com_free = "0"
-  worker_instance_count_org      = "0"
-
   worker_managed_instance_count_com      = "${length(var.worker_zones)}"
   worker_managed_instance_count_com_free = "1"
   worker_managed_instance_count_org      = "${length(var.worker_zones)}"

--- a/gce.mk
+++ b/gce.mk
@@ -39,28 +39,3 @@ import-net:
 .PHONY: export-net
 export-net:
 	$(TOP)/bin/gce-export-net --terraform $(TERRAFORM)
-
-# Imports worker resources from a GCE project that used a single terraform graph
-# to manage network resources and workers into a workers-only graph.  This
-# target is intended to be run within a given "non-net" graph directory such as
-# "gce-production-5".
-.PHONY: import-workers
-import-workers:
-	$(TOP)/bin/gce-import-workers \
-		--count-com $(shell jq -r .worker_instance_count_com <instance-counts.auto.tfvars) \
-		--count-org $(shell jq -r .worker_instance_count_org <instance-counts.auto.tfvars) \
-		--env $(ENV_SHORT) \
-		--index $(shell awk -F- '{ print $$NF }' <<<$(ENV_NAME)) \
-		--project $(shell $(TOP)/bin/lookup-gce-project $(ENV_NAME)) \
-		--terraform $(TERRAFORM)
-
-# Removes state references from a GCE project that has migrated worker resources
-# to a workers-only terraform graph (see `import-workers` above).  This target
-# is intended to be run within a given "non-net" graph directory such as
-# "gce-production-5".
-.PHONY: export-workers
-export-workers:
-	$(TOP)/bin/gce-export-workers \
-		--count-com $(shell jq -r .worker_instance_count_com <instance-counts.auto.tfvars) \
-		--count-org $(shell jq -r .worker_instance_count_org <instance-counts.auto.tfvars) \
-		--terraform $(TERRAFORM)

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -4,9 +4,6 @@ variable "config_org" {}
 variable "env" {}
 variable "github_users" {}
 variable "index" {}
-variable "instance_count_com" {}
-variable "instance_count_com_free" {}
-variable "instance_count_org" {}
 variable "managed_instance_count_com" {}
 variable "managed_instance_count_com_free" {}
 variable "managed_instance_count_org" {}
@@ -224,44 +221,6 @@ resource "google_compute_region_instance_group_manager" "worker_com" {
   distribution_policy_zones = "${formatlist("${var.region}-%s", var.zones)}"
 }
 
-resource "google_compute_instance" "worker_com" {
-  count = "${var.instance_count_com}"
-  name  = "${var.env}-${var.index}-worker-com-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
-
-  machine_type = "${var.machine_type}"
-  zone         = "${var.region}-${element(var.zones, count.index % length(var.zones))}"
-  tags         = ["worker", "${var.env}", "com", "paid"]
-  project      = "${var.project}"
-
-  boot_disk {
-    auto_delete = true
-
-    initialize_params {
-      image = "${var.worker_image}"
-      type  = "pd-ssd"
-    }
-  }
-
-  network_interface {
-    subnetwork = "${var.subnetwork_workers}"
-
-    access_config {
-      # ephemeral ip
-    }
-  }
-
-  metadata {
-    "block-project-ssh-keys" = "true"
-    "user-data"              = "${data.template_file.cloud_config_com.rendered}"
-  }
-
-  depends_on = ["null_resource.worker_com_validation"]
-
-  lifecycle {
-    ignore_changes = ["disk", "boot_disk"]
-  }
-}
-
 data "template_file" "cloud_init_env_com_free" {
   template = <<EOF
 export TRAVIS_WORKER_SELF_IMAGE="${var.worker_docker_self_image}"
@@ -351,44 +310,6 @@ resource "google_compute_region_instance_group_manager" "worker_com_free" {
   distribution_policy_zones = "${formatlist("${var.region}-%s", var.zones)}"
 }
 
-resource "google_compute_instance" "worker_com_free" {
-  count = "${var.instance_count_com_free}"
-  name  = "${var.env}-${var.index}-worker-com-free-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
-
-  machine_type = "${var.machine_type}"
-  zone         = "${var.region}-${element(var.zones, count.index % length(var.zones))}"
-  tags         = ["worker", "${var.env}", "com", "free"]
-  project      = "${var.project}"
-
-  boot_disk {
-    auto_delete = true
-
-    initialize_params {
-      image = "${var.worker_image}"
-      type  = "pd-ssd"
-    }
-  }
-
-  network_interface {
-    subnetwork = "${var.subnetwork_workers}"
-
-    access_config {
-      # ephemeral ip
-    }
-  }
-
-  metadata {
-    "block-project-ssh-keys" = "true"
-    "user-data"              = "${data.template_file.cloud_config_com_free.rendered}"
-  }
-
-  depends_on = ["null_resource.worker_com_free_validation"]
-
-  lifecycle {
-    ignore_changes = ["disk", "boot_disk"]
-  }
-}
-
 data "template_file" "cloud_init_env_org" {
   template = <<EOF
 export TRAVIS_WORKER_SELF_IMAGE="${var.worker_docker_self_image}"
@@ -476,44 +397,6 @@ resource "google_compute_region_instance_group_manager" "worker_org" {
   region             = "${var.region}"
 
   distribution_policy_zones = "${formatlist("${var.region}-%s", var.zones)}"
-}
-
-resource "google_compute_instance" "worker_org" {
-  count = "${var.instance_count_org}"
-  name  = "${var.env}-${var.index}-worker-org-${element(var.zones, count.index % length(var.zones))}-${(count.index / length(var.zones)) + 1}-gce"
-
-  machine_type = "${var.machine_type}"
-  zone         = "${var.region}-${element(var.zones, count.index % length(var.zones))}"
-  tags         = ["worker", "${var.env}", "org"]
-  project      = "${var.project}"
-
-  boot_disk {
-    auto_delete = true
-
-    initialize_params {
-      image = "${var.worker_image}"
-      type  = "pd-ssd"
-    }
-  }
-
-  network_interface {
-    subnetwork = "${var.subnetwork_workers}"
-
-    access_config {
-      # ephemeral ip
-    }
-  }
-
-  metadata {
-    "block-project-ssh-keys" = "true"
-    "user-data"              = "${data.template_file.cloud_config_org.rendered}"
-  }
-
-  depends_on = ["null_resource.worker_org_validation"]
-
-  lifecycle {
-    ignore_changes = ["disk", "boot_disk"]
-  }
 }
 
 output "workers_service_account_email" {

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -50,9 +50,6 @@ variable "worker_docker_self_image" {
 }
 
 variable "worker_image" {}
-variable "worker_instance_count_com" {}
-variable "worker_instance_count_com_free" {}
-variable "worker_instance_count_org" {}
 
 variable "worker_managed_instance_count_com" {
   default = 0
@@ -85,10 +82,6 @@ module "gce_workers" {
   env             = "${var.env}"
   github_users    = "${var.github_users}"
   index           = "${var.index}"
-
-  instance_count_com      = "${var.worker_instance_count_com}"
-  instance_count_com_free = "${var.worker_instance_count_com_free}"
-  instance_count_org      = "${var.worker_instance_count_org}"
 
   managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"


### PR DESCRIPTION
Oh god, the double meaning of these words is terrible, I'm so sorry.

All worker instances have been moved to managed instance groups. This is effectively dead code, since all the counts have been set to 0 for a while.