### PR TITLE
Handle terraform v0.12 lib incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - PATH="${HOME}/bin:${PATH}"
   - TMPDIR="${TMPDIR:-/tmp}"
 before_install:
-- eval "$(gimme 1.9.4)"
+- eval "$(gimme 1.11.1)"
 - make deps
 script:
 - make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELLCHECK_URL := https://s3.amazonaws.com/travis-blue-public/binaries/ubuntu/14.04/x86_64/shellcheck-0.4.4.tar.bz2
 SHFMT_URL := https://github.com/mvdan/sh/releases/download/v2.5.0/shfmt_v2.5.0_linux_amd64
 TFPLAN2JSON_URL := github.com/travis-ci/tfplan2json
+TFPLAN2JSON_V11_URL := gopkg.in/travis-ci/tfplan2json.v11
 PROVIDER_TRAVIS_URL := github.com/travis-ci/terraform-provider-travis
 
 DEPS := \
@@ -57,7 +58,8 @@ $(GOPATH_BIN)/shfmt:
 
 .PHONY: .ensure-tfplan2json
 .ensure-tfplan2json:
-	$(GO) get -u "$(TFPLAN2JSON_URL)"
+	$(SHELL) -c 'eval $$(gimme 1.11.1) && $(GO) get -u "$(TFPLAN2JSON_URL)"'
+	$(SHELL) -c 'eval $$(gimme 1.9.7) && $(GO) get -u "$(TFPLAN2JSON_V11_URL)"'
 
 .PHONY: .ensure-provider-travis
 .ensure-provider-travis:

--- a/bin/tfplandiff
+++ b/bin/tfplandiff
@@ -5,13 +5,19 @@ def main
   fail 'Missing {tfplan} input as first argument' if tfplan_filename.nil?
 
   differ = ENV.fetch('TFPLANDIFF_DIFFER', 'diff')
+  tfversion = ENV.fetch('PROD_TF_VERSION', '???')
 
   require 'base64'
   require 'json'
   require 'tmpdir'
   require 'yaml'
 
-  tfplan = JSON.parse(`tfplan2json <#{tfplan_filename}`)
+  tfplan2json_command = "tfplan2json #{tfplan_filename}"
+  if tfversion < 'v0.12'
+    tfplan2json_command = "tfplan2json.v11 <#{tfplan_filename}"
+  end
+
+  tfplan = JSON.parse(`#{tfplan2json_command}`)
 
   trunc_filename = tfplan_filename.sub(Dir.pwd, '.')
   $stdout.puts <<~PREAMBLE

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -15,8 +15,11 @@ AMQP_URL_VARNAME ?= AMQP_URL
 TOP := $(shell git rev-parse --show-toplevel)
 NATBZ2 := $(TOP)/assets/nat.tar.bz2
 
-PROD_TF_VERSION := v0.11.8
+PROD_TF_VERSION := v0.11.10
 TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
+
+export PROD_TF_VERSION
+export TERRAFORM
 
 .PHONY: hello
 hello: announce


### PR DESCRIPTION
and bump the default `PROD_TF_VERSION` to v0.11.10

## What is the problem that this PR is trying to fix?

The version of `tfplan2json` on the master branch can't be built with golang 1.9.4 and the latest master branch of terraform is incompatible with the most recent release of terraform.

## What approach did you choose and why?

Break up `tfplan2json` into two branches and pull them separately to create two separate executables from which a version is picked at runtime based on `PROD_TF_VERSION`.