### PR TITLE
gce-production-3: resurrect, add NAT IPs to DNS

### DIFF
--- a/dns-production-0/main.tf
+++ b/dns-production-0/main.tf
@@ -55,6 +55,10 @@ data "dns_a_record_set" "gce_production_2_nat" {
   host = "nat-production-2.gce-us-central1.travisci.net"
 }
 
+data "dns_a_record_set" "gce_production_3_nat" {
+  host = "nat-production-3.gce-us-central1.travisci.net"
+}
+
 resource "aws_route53_record" "aws_nat" {
   zone_id = "${var.travisci_net_external_zone_id}"
   name    = "nat.aws-us-east-1.travisci.net"
@@ -76,6 +80,7 @@ resource "aws_route53_record" "gce_nat" {
   records = [
     "${data.dns_a_record_set.gce_production_1_nat.addrs}",
     "${data.dns_a_record_set.gce_production_2_nat.addrs}",
+    "${data.dns_a_record_set.gce_production_3_nat.addrs}",
   ]
 }
 
@@ -111,6 +116,7 @@ resource "aws_route53_record" "nat" {
     "${data.dns_a_record_set.aws_production_2_nat_org.addrs}",
     "${data.dns_a_record_set.gce_production_1_nat.addrs}",
     "${data.dns_a_record_set.gce_production_2_nat.addrs}",
+    "${data.dns_a_record_set.gce_production_3_nat.addrs}",
     "${var.macstadium_production_nat_addrs}",
   ]
 }
@@ -136,6 +142,8 @@ resource "heroku_app" "whereami" {
       join(",", data.dns_a_record_set.gce_production_1_nat.addrs)
     },${
       join(",", data.dns_a_record_set.gce_production_2_nat.addrs)
+    },${
+      join(",", data.dns_a_record_set.gce_production_3_nat.addrs)
     }"
 
     WHEREAMI_INFRA_MACSTADIUM_IPS = "${


### PR DESCRIPTION
The second step in resurrecting the production-3 project is to announce the IP addresses. This patch adds them to DNS which AFAIK should make them show up in [our docs](https://docs.travis-ci.com/user/ip-addresses/) automatically, possibly pending a docs rebuild.

refs https://github.com/travis-ci/reliability/issues/217