### PR TITLE
gce-production-3: resurrect, managed instance groups

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -83,6 +83,17 @@ data "terraform_remote_state" "production_2" {
   }
 }
 
+data "terraform_remote_state" "production_3" {
+  backend = "s3"
+
+  config {
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-3.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "travis-terraform-state"
+  }
+}
+
 module "aws_iam_user_s3_com" {
   source = "../modules/aws_iam_user_s3"
 
@@ -185,4 +196,11 @@ resource "google_project_iam_member" "production_2_workers" {
   project = "${var.project}"
   role    = "roles/compute.imageUser"
   member  = "serviceAccount:${element(data.terraform_remote_state.production_2.workers_service_account_emails, count.index)}"
+}
+
+resource "google_project_iam_member" "production_3_workers" {
+  count   = "${length(data.terraform_remote_state.production_3.workers_service_account_emails)}"
+  project = "${var.project}"
+  role    = "roles/compute.imageUser"
+  member  = "serviceAccount:${element(data.terraform_remote_state.production_3.workers_service_account_emails, count.index)}"
 }

--- a/gce-production-3/instance-counts.auto.tfvars
+++ b/gce-production-3/instance-counts.auto.tfvars
@@ -1,2 +1,5 @@
 {
+  "worker_managed_instance_count_com": 0,
+  "worker_managed_instance_count_org": 0,
+  "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -5,10 +5,6 @@ variable "env" {
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
-variable "gce_worker_image" {
-  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1516675156-0b5be43"
-}
-
 variable "github_users" {}
 
 variable "index" {
@@ -27,6 +23,10 @@ variable "syslog_address_org" {}
 variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
+
+variable "worker_managed_instance_count_com" {}
+variable "worker_managed_instance_count_org" {}
+variable "worker_managed_instance_count_com_free" {}
 
 variable "worker_zones" {
   default = ["a", "b", "f"]
@@ -59,4 +59,98 @@ data "terraform_remote_state" "vpc" {
     region         = "us-east-1"
     dynamodb_table = "travis-terraform-state"
   }
+}
+
+module "aws_iam_user_s3_com" {
+  source = "../modules/aws_iam_user_s3"
+
+  iam_user_name  = "worker-gce-${var.env}-${var.index}-com"
+  s3_bucket_name = "build-trace.travis-ci.com"
+}
+
+module "aws_iam_user_s3_org" {
+  source = "../modules/aws_iam_user_s3"
+
+  iam_user_name  = "worker-gce-${var.env}-${var.index}-org"
+  s3_bucket_name = "build-trace.travis-ci.org"
+}
+
+module "gce_worker_group" {
+  source = "../modules/gce_worker_group"
+
+  env                                       = "${var.env}"
+  gcloud_cleanup_job_board_url              = "${var.job_board_url}"
+  gcloud_cleanup_opencensus_sampling_rate   = "10"
+  gcloud_cleanup_opencensus_tracing_enabled = "true"
+  gcloud_zone                               = "${var.gce_gcloud_zone}"
+  github_users                              = "${var.github_users}"
+  heroku_org                                = "${var.gce_heroku_org}"
+  index                                     = "${var.index}"
+  project                                   = "${var.project}"
+  region                                    = "us-central1"
+  syslog_address_com                        = "${var.syslog_address_com}"
+  syslog_address_org                        = "${var.syslog_address_org}"
+  travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
+  worker_subnetwork                         = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
+
+  worker_zones = "${var.worker_zones}"
+
+  worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
+  worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
+  worker_managed_instance_count_org      = "${var.worker_managed_instance_count_org}"
+
+  worker_service_accounts_count_com      = "${var.worker_managed_instance_count_com / 4}"
+  worker_service_accounts_count_com_free = "${var.worker_managed_instance_count_com_free / 4}"
+  worker_service_accounts_count_org      = "${var.worker_managed_instance_count_org / 4}"
+
+  worker_config_com = <<EOF
+### worker.env
+${file("${path.module}/worker.env")}
+### config/worker-com.env
+${file("${path.module}/config/worker-com.env")}
+
+export TRAVIS_WORKER_GCE_SUBNETWORK=jobs-com
+export TRAVIS_WORKER_HARD_TIMEOUT=120m
+export TRAVIS_WORKER_QUEUE_NAME=builds.gce
+export TRAVIS_WORKER_TRAVIS_SITE=com
+
+export TRAVIS_WORKER_BUILD_TRACE_S3_BUCKET=${module.aws_iam_user_s3_com.bucket}
+export AWS_ACCESS_KEY_ID=${module.aws_iam_user_s3_com.id}
+export AWS_SECRET_ACCESS_KEY=${module.aws_iam_user_s3_com.secret}
+EOF
+
+  worker_config_com_free = <<EOF
+### worker.env
+${file("${path.module}/worker.env")}
+### config/worker-com.env
+${file("${path.module}/config/worker-com.env")}
+
+export TRAVIS_WORKER_QUEUE_NAME=builds.gce-free
+export TRAVIS_WORKER_GCE_SUBNETWORK=jobs-com
+export TRAVIS_WORKER_HARD_TIMEOUT=120m
+export TRAVIS_WORKER_TRAVIS_SITE=com
+
+export TRAVIS_WORKER_BUILD_TRACE_S3_BUCKET=${module.aws_iam_user_s3_com.bucket}
+export AWS_ACCESS_KEY_ID=${module.aws_iam_user_s3_com.id}
+export AWS_SECRET_ACCESS_KEY=${module.aws_iam_user_s3_com.secret}
+EOF
+
+  worker_config_org = <<EOF
+### worker.env
+${file("${path.module}/worker.env")}
+### config/worker-org.env
+${file("${path.module}/config/worker-org.env")}
+
+export TRAVIS_WORKER_QUEUE_NAME=builds.gce
+export TRAVIS_WORKER_GCE_SUBNETWORK=jobs-org
+export TRAVIS_WORKER_TRAVIS_SITE=org
+
+export TRAVIS_WORKER_BUILD_TRACE_S3_BUCKET=${module.aws_iam_user_s3_org.bucket}
+export AWS_ACCESS_KEY_ID=${module.aws_iam_user_s3_org.id}
+export AWS_SECRET_ACCESS_KEY=${module.aws_iam_user_s3_org.secret}
+EOF
+}
+
+output "workers_service_account_emails" {
+  value = ["${module.gce_worker_group.workers_service_account_emails}"]
 }


### PR DESCRIPTION
The next step in this saga is to resurrect the managed instance group. It is still set to 0 instances for now.

We need to announce the new NAT IPs before we can start shifting traffic to this project.

This patch puts the infrastructure in place. Once we're ready to do that, we can play with the numbers in `instance-counts.auto.tfvars`, and use `worker-deploy` to drain some of the instances in the other two projects.

refs travis-ci/reliability#217