### PR TITLE
Decommission a single macstadium prod worker

### DIFF
--- a/macstadium-prod-1-cluster/main.tf
+++ b/macstadium-prod-1-cluster/main.tf
@@ -97,3 +97,44 @@ output "imaged_secret_key" {
   value     = "${module.aws_iam_user_s3_imaged.secret}"
   sensitive = true
 }
+
+// These users are for the worker instances that will run on the cluster.
+// The credentials are outputs so they can be copied into the keychain.
+//
+// If the users ever get recreated, those credentials need to get copied
+// again so the Kubernetes secrets can be updated.
+//
+// This is not ideal, so I'd like to find a better way to manage this at
+// point.
+
+module "worker_com_s3_user" {
+  source         = "../modules/aws_iam_user_s3"
+  iam_user_name  = "worker-macstadium-prod-1-com"
+  s3_bucket_name = "build-trace.travis-ci.com"
+}
+
+output "worker_com_access_key" {
+  value     = "${module.worker_com_s3_user.id}"
+  sensitive = true
+}
+
+output "worker_com_secret_key" {
+  value     = "${module.worker_com_s3_user.secret}"
+  sensitive = true
+}
+
+module "worker_org_s3_user" {
+  source         = "../modules/aws_iam_user_s3"
+  iam_user_name  = "worker-macstadium-prod-1-org"
+  s3_bucket_name = "build-trace.travis-ci.org"
+}
+
+output "worker_org_access_key" {
+  value     = "${module.worker_org_s3_user.id}"
+  sensitive = true
+}
+
+output "worker_org_secret_key" {
+  value     = "${module.worker_org_s3_user.secret}"
+  sensitive = true
+}

--- a/macstadium-prod-1/workers.tf
+++ b/macstadium-prod-1/workers.tf
@@ -141,7 +141,7 @@ module "worker_production_org_4" {
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_TRAVIS_SITE="org"
-export TRAVIS_WORKER_POOL_SIZE="${var.worker_org_pool_size}"
+export TRAVIS_WORKER_POOL_SIZE="0"
 export TRAVIS_WORKER_PPROF_PORT="7073"
 export TRAVIS_WORKER_HTTP_API_AUTH="macstadium-worker:${random_id.travis_worker_production_org_token.hex}"
 export TRAVIS_WORKER_JUPITERBRAIN_ENDPOINT="http://${random_id.jupiter_brain_production_org_token.hex}@127.0.0.1:8081/"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We want to slowly but surely migrate the MacStadium-based infra to run on Kubernetes. We have a cluster running, so now we can start moving things over, one worker at a time.

## What approach did you choose and why?

Pool size of `travis-worker-production-org-4` is reduced to zero so that we can gracefully bring down the worker before removing it entirely. If we didn't do this, we'd have to either stop it forcefully or it would just restart again after a graceful shutdown. So I've opted to remove its pool so at least it won't scoop up jobs when we gracefully shut it down.

I also added S3 users for build tracing for the Kubernetes-based workers.

## How can you test this?

Arguably, this is the test! This will be the process we use for other workers, and this is the first test of doing that on a small section of our infrastructure.

## What feedback would you like, if any?

Any.