### PR TITLE
gce-production-3: resurrect, capacity

### DIFF
--- a/gce-production-1/instance-counts.auto.tfvars
+++ b/gce-production-1/instance-counts.auto.tfvars
@@ -1,5 +1,5 @@
 {
-  "worker_managed_instance_count_com": 27,
-  "worker_managed_instance_count_org": 33,
+  "worker_managed_instance_count_com": 18,
+  "worker_managed_instance_count_org": 22,
   "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-2/instance-counts.auto.tfvars
+++ b/gce-production-2/instance-counts.auto.tfvars
@@ -1,5 +1,5 @@
 {
-  "worker_managed_instance_count_com": 27,
-  "worker_managed_instance_count_org": 33,
+  "worker_managed_instance_count_com": 18,
+  "worker_managed_instance_count_org": 22,
   "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-3/instance-counts.auto.tfvars
+++ b/gce-production-3/instance-counts.auto.tfvars
@@ -1,5 +1,5 @@
 {
-  "worker_managed_instance_count_com": 0,
-  "worker_managed_instance_count_org": 0,
+  "worker_managed_instance_count_com": 18,
+  "worker_managed_instance_count_org": 22,
   "worker_managed_instance_count_com_free": 0
 }


### PR DESCRIPTION
This patch restores capacity to the production-3 project. It does so by re-distributing the number of workers evenly between the three projects.

* Before we do this, we are having another chat about getting our API quotas raised, which might make this patch moot, fingers crossed.
* If we want to move forward with this, it might be good to apply for some quota increases on prod-3, to get the quotas in the same realm as prod-1 and prod-2. We will want 30 req/s instead of the current 20.
* In order to roll this out, we will need to drain some capacity from the current projects. That will be something along the lines of:
  ```
  bin/worker-deploy-gce drain production-1 worker-com --limit=9
  bin/worker-deploy-gce drain production-1 worker-org --limit=11
  bin/worker-deploy-gce decom production-1

  bin/worker-deploy-gce drain production-2 worker-com --limit=9
  bin/worker-deploy-gce drain production-2 worker-org --limit=11
  bin/worker-deploy-gce decom production-2
  ```

refs https://github.com/travis-ci/reliability/issues/217