### PR TITLE
gce_net: remove instance-hostname.tmpl from GCE NATs

### DIFF
--- a/bin/gcloud-recreate-nat-instances
+++ b/bin/gcloud-recreate-nat-instances
@@ -43,7 +43,7 @@ def main
   groups_zones = Hash[groups_zones]
 
   groups_zones.each do |instance_group, zone|
-    instance_list = list_instances(instance_group, zone)
+    instance_list = list_instances(instance_group, zone, project)
     instances = instance_list.map { |r| r.fetch('instance').split('/').last }
     command = %W[
       gcloud compute instance-groups managed recreate-instances
@@ -56,7 +56,7 @@ def main
   0
 end
 
-def list_instances(instance_group, zone)
+def list_instances(instance_group, zone, project)
   command = %W[
     gcloud compute instance-groups list-instances
     #{instance_group}

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -425,10 +425,9 @@ resource "google_compute_route" "nat" {
 
 data "template_file" "nat_rolling_updater_config" {
   template = <<EOF
-export GCE_NAT_ROLLING_UPDATER_PROJECT='${var.project}'
-export GCE_NAT_ROLLING_UPDATER_REGION='${var.region}'
-export GCE_NAT_ROLLING_UPDATER_GROUPS='${join(",", google_compute_instance_group_manager.nat.*.name)}'
-export GCE_NAT_ROLLING_UPDATER_TEMPLATES='${join(",", google_compute_instance_template.nat.*.name)}'
+export GCE_NAT_PROJECT='${var.project}'
+export GCE_NAT_REGION='${var.region}'
+export GCE_NAT_GROUPS='${join(",", google_compute_instance_group_manager.nat.*.name)}'
 EOF
 }
 

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -274,7 +274,6 @@ data "template_file" "nat_cloud_config" {
   vars {
     assets            = "${path.module}/../../assets"
     cloud_init_bash   = "${file("${path.module}/nat-cloud-init.bash")}"
-    instance_hostname = "nat-${var.env}-${var.index}-___INSTANCE_ID___.gce-___REGION_ZONE___.travisci.net"
     nat_config        = "${var.nat_config}"
     syslog_address    = "${var.syslog_address}"
 

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -272,10 +272,10 @@ data "template_file" "nat_cloud_config" {
   template = "${file("${path.module}/nat-cloud-config.yml.tpl")}"
 
   vars {
-    assets            = "${path.module}/../../assets"
-    cloud_init_bash   = "${file("${path.module}/nat-cloud-init.bash")}"
-    nat_config        = "${var.nat_config}"
-    syslog_address    = "${var.syslog_address}"
+    assets          = "${path.module}/../../assets"
+    cloud_init_bash = "${file("${path.module}/nat-cloud-init.bash")}"
+    nat_config      = "${var.nat_config}"
+    syslog_address  = "${var.syslog_address}"
 
     github_users_env = <<EOF
 export GITHUB_USERS='${var.github_users}'

--- a/modules/gce_net/nat-cloud-config.yml.tpl
+++ b/modules/gce_net/nat-cloud-config.yml.tpl
@@ -25,9 +25,6 @@ write_files:
 - content: '${base64encode(file("${assets}/nat.tar.bz2"))}'
   encoding: b64
   path: /var/tmp/nat.tar.bz2
-- content: '${base64encode(instance_hostname)}'
-  encoding: b64
-  path: /var/tmp/travis-run.d/instance-hostname.tmpl
 - content: '${base64encode(syslog_address)}'
   encoding: b64
   path: /var/tmp/travis-run.d/syslog-address


### PR DESCRIPTION
Changing the hostname makes it harder to correlate metrics in librato with the actual instance name in GCP. Librato gets `nat-production-1-532642592` whereas the host gets `production-1-nat-a-1-9cnw`.

We've also seen issues with these names flapping after restarts, creating false positive NAT alerts.

We'll probably have to drain a project at a time to roll this out safely.