### PR TITLE
Remove Android from language mapping

### DIFF
--- a/aws-production-2/generated-language-mapping.json
+++ b/aws-production-2/generated-language-mapping.json
@@ -1,5 +1,4 @@
 {
-  "android": "travisci/ci-amethyst:packer-1512508255-986baf0",
   "erlang": "travisci/ci-amethyst:packer-1512508255-986baf0",
   "haskell": "travisci/ci-amethyst:packer-1512508255-986baf0",
   "perl": "travisci/ci-amethyst:packer-1512508255-986baf0",


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Unhelpfully suggesting to run debug builds for android on an image that does not support it, see https://github.com/travis-ci/docs-travis-ci-com/blob/7f7ae1803208ec311f722eed441be74381e58f26/Rakefile#L100

## What approach did you choose and why?
Remove the language mapping

## How can you test this?

## What feedback would you like, if any?