### PR TITLE
Disable plan/apply targets for ec2 staging resources

### DIFF
--- a/aws-shared-1/Makefile
+++ b/aws-shared-1/Makefile
@@ -8,3 +8,9 @@ default: hello
 
 .PHONY: .config
 .config: $(ENV_NAME).auto.tfvars
+
+plan:
+	@echo NO
+
+apply:
+	@echo STILL NO

--- a/aws-staging-1/Makefile
+++ b/aws-staging-1/Makefile
@@ -4,3 +4,9 @@ JOB_BOARD_HOST := job-board-staging.travis-ci.com
 AMQP_URL_VARNAME := CLOUDAMQP_URL
 
 include $(shell git rev-parse --show-toplevel)/aws.mk
+
+plan:
+	@echo NO
+
+apply:
+	@echo STILL NO


### PR DESCRIPTION
so that nobody accidentally recreates stuff before these files are removed entirely.