### PR TITLE
Remove us-central1-b from production GCE zones

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -111,6 +111,8 @@ module "gce_worker_group" {
   travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
   worker_subnetwork                         = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
+  worker_zones = ["a", "c", "f"]
+
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
   worker_managed_instance_count_org      = "${var.worker_managed_instance_count_org}"

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -89,6 +89,8 @@ module "gce_worker_group" {
   travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
   worker_subnetwork                         = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
+  worker_zones = ["a", "c", "f"]
+
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
   worker_managed_instance_count_org      = "${var.worker_managed_instance_count_org}"


### PR DESCRIPTION
because it is currently experiencing heightened zone resource pool exhaustion errors.

I'm not certain this is the best plan, given that we have also experienced this error recently in us-central1-f, and the current error rate for us-central1-b is fairly low :thinking: 

See also: https://github.com/travis-ci/worker/pull/572