### PR TITLE
Move custom-2 worker on pod-2 to target .com

### DIFF
--- a/macstadium-prod-2/workers.tf
+++ b/macstadium-prod-2/workers.tf
@@ -291,7 +291,7 @@ module "worker_custom_2" {
   env                = "custom-2"
   index              = "${var.index}"
   worker_base_config = "${data.template_file.worker_config_common.rendered}"
-  worker_env_config  = "${file("${path.module}/config/travis-worker-production-org-common")}"
+  worker_env_config  = "${file("${path.module}/config/travis-worker-production-com-common")}"
 
   worker_local_config = <<EOF
 export TRAVIS_WORKER_HARD_TIMEOUT=120m


### PR DESCRIPTION
This customer has finished moving their repos to .com, so we want to give their full capacity towards .com and stop targeting .org.