### PR TITLE
 Restore pool sizes for Mac workers in pod-2 after vCenter 6.7 migration

### DIFF
--- a/macstadium-prod-2/workers.tf
+++ b/macstadium-prod-2/workers.tf
@@ -5,15 +5,15 @@ variable "travis_worker_version" {
 }
 
 variable "worker_org_pool_size" {
-  default = 0
+  default = 41
 }
 
 variable "worker_com_pool_size" {
-  default = 0
+  default = 28
 }
 
 variable "worker_custom_pool_size" {
-  default = 0
+  default = 5
 }
 
 resource "random_id" "travis_worker_production_org_token" {


### PR DESCRIPTION
Undo the work in https://github.com/travis-ci/terraform-config/pull/652, restoring the pool sizes to their original capacity.