### PR TITLE
Allow logging into K8s clusters with GitHub tokens

### DIFF
--- a/modules/macstadium_k8s_cluster/scripts/guard.sh.tpl
+++ b/modules/macstadium_k8s_cluster/scripts/guard.sh.tpl
@@ -1,0 +1,69 @@
+#!/bin/bash
+# vim: set ft=sh :
+
+set -e
+
+ORG="${org}"
+ADMIN_TEAM="${admin_team}"
+
+GUARD_DATA_DIR=$(mktemp -d)
+export GUARD_DATA_DIR
+
+wget -O /usr/local/bin/guard https://github.com/appscode/guard/releases/download/0.3.0/guard-linux-amd64 \
+  && chmod +x /usr/local/bin/guard
+
+guard init ca
+guard init server --ips="10.96.10.96"
+guard init client "$ORG" -o github
+
+# Delete any existing Guard instance
+kubectl delete deployment guard -n kube-system || true
+
+guard get installer --auth-providers=github >"$GUARD_DATA_DIR/installer.yaml"
+kubectl apply -f "$GUARD_DATA_DIR/installer.yaml"
+
+mkdir -p /etc/kubernetes/guard
+guard get webhook-config "$ORG" -o github --addr="10.96.10.96:443" >/etc/kubernetes/guard/webhook.yaml
+
+python <<SCRIPT >"$GUARD_DATA_DIR/kube-apiserver.yaml"
+import yaml
+config = yaml.safe_load(open('/etc/kubernetes/manifests/kube-apiserver.yaml').read())
+cmd = config['spec']['containers'][0]['command']
+mounts = config['spec']['containers'][0]['volumeMounts']
+volumes = config['spec']['volumes']
+
+new_arg = '--authentication-token-webhook-config-file=/etc/kubernetes/guard/webhook.yaml'
+if new_arg not in cmd:
+  cmd.append(new_arg)
+
+if not any(v['name'] == 'guard' for v in mounts):
+  mounts.append({ 'readOnly': True, 'mountPath': '/etc/kubernetes/guard', 'name': 'guard' })
+
+if not any(v['name'] == 'guard' for v in volumes):
+  volumes.append({ 'hostPath': { 'path': '/etc/kubernetes/guard', 'type': 'DirectoryOrCreate' }, 'name': 'guard' })
+
+print yaml.dump(config, default_flow_style=False)
+SCRIPT
+
+cp /etc/kubernetes/manifests/kube-apiserver.yaml "$GUARD_DATA_DIR/kube-apiserver-backup.yaml"
+cp "$GUARD_DATA_DIR/kube-apiserver.yaml" /etc/kubernetes/manifests/kube-apiserver.yaml
+
+# Travis CI employees are admins on the cluster
+kubectl apply -f - <<RESOURCE
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: employees-team
+subjects:
+- kind: Group
+  name: $ADMIN_TEAM
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+RESOURCE
+
+# Restart the API server in case we didn't actually have to change it
+# This ensures we pick up the most current webhook config
+kubectl delete pod -l component=kube-apiserver -n kube-system

--- a/modules/macstadium_k8s_cluster/variables.tf
+++ b/modules/macstadium_k8s_cluster/variables.tf
@@ -55,3 +55,13 @@ variable "travisci_net_external_zone_id" {
 variable "ssh_user" {
   description = "your SSH username on our vanilla Linux images"
 }
+
+variable "auth_org" {
+  default     = "travis-ci"
+  description = "The GitHub organization for users of this cluster"
+}
+
+variable "auth_admin_team" {
+  default     = "Employees"
+  description = "The GitHub team in the organization whose users will be made admins of the cluster"
+}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Fixes travis-ci/kubernetes-config#21.

Until now, the only way to login to the MacStadium Kubernetes clusters was to use the client certificate that kubeadm generates. This doesn't allow us fine-grained control over who has access. It also meant that the only real way to run the Kubernetes dashboard was to have it wide-open to anyone who could reach it, and rely on the VPN to protect us. Unfortunately, that leaves it exposed to job VMs, which could access the dashboard and do anything they wanted to the cluster.

## What approach did you choose and why?

I used a tool called [Guard](https://appscode.com/products/guard/), which runs a server that can review token auth requests for the Kubernetes API server. I added a new null_resource for MacStadium clusters to set up guard on the cluster's master. By default, it will use the `travis-ci` GitHub org for checking users, and the "Employees" team within that org will be given full access to the cluster. Other bindings can be set up if desired from `kubectl`, but this provides an easy out-of-the-box experience when using this module.

Once this is set up, you can create a user in your .kubeconfig by running:

```
kubectl config set-credentials mjm --token=<token>
```

The token can be created in the developer settings of your GitHub profile, it only needs read:org privileges.

Then you can use that user as the credentials for any contexts for clusters set up with Guard.

## How can you test this?

I've run this on macstadium-staging and am able to connect to the staging cluster using a GitHub PAT instead of a client certificate!

## What feedback would you like, if any?

Any.