### PR TITLE
Deploy new VM images for MacStadium Kubernetes nodes

### DIFF
--- a/macstadium-staging/main.tf
+++ b/macstadium-staging/main.tf
@@ -25,6 +25,8 @@ provider "aws" {
 }
 
 provider "vsphere" {
+  version = "~> 1.8"
+
   user                 = "${var.vsphere_user}"
   password             = "${var.vsphere_password}"
   vsphere_server       = "${var.vsphere_server}"

--- a/modules/macstadium_k8s_cluster/master.tf
+++ b/modules/macstadium_k8s_cluster/master.tf
@@ -11,14 +11,14 @@ resource "vsphere_virtual_machine" "master" {
 
   num_cpus  = 4
   memory    = 4096
-  guest_id  = "${data.vsphere_virtual_machine.vanilla_template.guest_id}"
-  scsi_type = "${data.vsphere_virtual_machine.vanilla_template.scsi_type}"
+  guest_id  = "${data.vsphere_virtual_machine.master_vanilla_template.guest_id}"
+  scsi_type = "${data.vsphere_virtual_machine.master_vanilla_template.scsi_type}"
 
   disk {
     label            = "disk0"
-    size             = "${data.vsphere_virtual_machine.vanilla_template.disks.0.size}"
-    eagerly_scrub    = "${data.vsphere_virtual_machine.vanilla_template.disks.0.eagerly_scrub}"
-    thin_provisioned = "${data.vsphere_virtual_machine.vanilla_template.disks.0.thin_provisioned}"
+    size             = "${data.vsphere_virtual_machine.master_vanilla_template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.master_vanilla_template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.master_vanilla_template.disks.0.thin_provisioned}"
   }
 
   network_interface {
@@ -26,7 +26,7 @@ resource "vsphere_virtual_machine" "master" {
   }
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.vanilla_template.id}"
+    template_uuid = "${data.vsphere_virtual_machine.master_vanilla_template.id}"
 
     customize {
       network_interface {

--- a/modules/macstadium_k8s_cluster/nodes.tf
+++ b/modules/macstadium_k8s_cluster/nodes.tf
@@ -14,14 +14,14 @@ resource "vsphere_virtual_machine" "nodes" {
 
   num_cpus  = 4
   memory    = 4096
-  guest_id  = "${data.vsphere_virtual_machine.vanilla_template.guest_id}"
-  scsi_type = "${data.vsphere_virtual_machine.vanilla_template.scsi_type}"
+  guest_id  = "${data.vsphere_virtual_machine.node_vanilla_template.guest_id}"
+  scsi_type = "${data.vsphere_virtual_machine.node_vanilla_template.scsi_type}"
 
   disk {
     label            = "disk0"
-    size             = "${data.vsphere_virtual_machine.vanilla_template.disks.0.size}"
-    eagerly_scrub    = "${data.vsphere_virtual_machine.vanilla_template.disks.0.eagerly_scrub}"
-    thin_provisioned = "${data.vsphere_virtual_machine.vanilla_template.disks.0.thin_provisioned}"
+    size             = "${data.vsphere_virtual_machine.node_vanilla_template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.node_vanilla_template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.node_vanilla_template.disks.0.thin_provisioned}"
   }
 
   network_interface {
@@ -35,7 +35,7 @@ resource "vsphere_virtual_machine" "nodes" {
   }
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.vanilla_template.id}"
+    template_uuid = "${data.vsphere_virtual_machine.node_vanilla_template.id}"
 
     customize {
       network_interface {
@@ -67,16 +67,8 @@ resource "vsphere_virtual_machine" "nodes" {
     agent = true
   }
 
-  provisioner "file" {
-    source      = "${path.module}/scripts/"
-    destination = "/tmp"
-  }
-
   provisioner "remote-exec" {
     inline = [
-      "sudo chmod a+x /tmp/*.sh",
-      "sudo /tmp/install-docker.sh",
-      "sudo /tmp/install-kubernetes.sh",
       "sudo ${lookup(data.external.kubeadm_join.result, "command")}",
     ]
   }

--- a/modules/macstadium_k8s_cluster/providers.tf
+++ b/modules/macstadium_k8s_cluster/providers.tf
@@ -29,7 +29,12 @@ data "vsphere_network" "management" {
 }
 */
 
-data "vsphere_virtual_machine" "vanilla_template" {
-  name          = "Vanilla VMs/${var.vanilla_image}"
+data "vsphere_virtual_machine" "master_vanilla_template" {
+  name          = "Vanilla VMs/${var.master_vanilla_image}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "node_vanilla_template" {
+  name          = "Vanilla VMs/${var.node_vanilla_image}"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }

--- a/modules/macstadium_k8s_cluster/variables.tf
+++ b/modules/macstadium_k8s_cluster/variables.tf
@@ -14,9 +14,14 @@ variable "node_count" {
   default = 1
 }
 
-variable "vanilla_image" {
+variable "master_vanilla_image" {
   default     = "travis-ci-ubuntu16.04-internal-vanilla-1540931726"
-  description = "The image to clone VMs from. Needs to be at least Xenial to support Kubernetes."
+  description = "The image to clone the master VM from. Needs to be at least Xenial to support Kubernetes."
+}
+
+variable "node_vanilla_image" {
+  default     = "travis-ci-centos7-internal-kubernetes-1549480185"
+  description = "The image to clone node VMs from. It should already have Kubernetes installed."
 }
 
 variable "datacenter" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Our Kubernetes nodes are too low on disk-space (https://github.com/travis-ci/team-infra/issues/856), so they need new images with more disk space. When we tried to deploy a new Xenial image, it wouldn't customize successfully due to some issue between it and ESXi 6.7.

A few bald yaks later...

## What approach did you choose and why?

Built a new image using CentOS 7 (which does customize successfully) and preinstall Kubernetes on it. Update the module so we can specify different images for master and node, since we only want to replace the nodes at this time.

This has to be set up somewhat manually: a single node needs to be upgraded at a time, and it needs to be drained of its pods before doing so, and uncordoned afterwards to be able to schedule again.

## How can you test this?

I've deployed this in `macstadium-staging` and it seems to be running alright.

## What feedback would you like, if any?

Any.