### PR TITLE
Bring up new DHCP server for pod-1 on modern Terraform and OS

### DIFF
--- a/macstadium-prod-1-cluster/dhcp.tf
+++ b/macstadium-prod-1-cluster/dhcp.tf
@@ -1,0 +1,13 @@
+module "dhcp_server" {
+  source                        = "../modules/macstadium_dhcp_server_2"
+  index                         = 1
+  datacenter                    = "pod-1"
+  cluster                       = "MacPro_Pod_1"
+  datastore                     = "DataCore1_1"
+  internal_network_label        = "Internal"
+  jobs_network_label            = "Jobs-1"
+  jobs_network_subnet           = "10.182.0.0/18"
+  mac_address                   = "00:50:56:84:b4:81"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+  ssh_user                      = "${var.ssh_user}"
+}

--- a/macstadium-prod-1/main.tf
+++ b/macstadium-prod-1/main.tf
@@ -91,15 +91,6 @@ module "macstadium_infrastructure" {
   custom_6_name                 = "${var.custom_6_name}"
 }
 
-module "dhcp_server" {
-  source              = "../modules/macstadium_dhcp_server"
-  host_id             = "${module.macstadium_infrastructure.dhcp_server_uuid}"
-  index               = "${var.index}"
-  jobs_network_subnet = "${var.jobs_network_subnet}"
-  ssh_host            = "${module.macstadium_infrastructure.dhcp_server_ip}"
-  ssh_user            = "${var.ssh_user}"
-}
-
 resource "random_id" "collectd_vsphere_collectd_network_token" {
   byte_length = 32
 }

--- a/modules/macstadium_dhcp_server_2/dhcp-server.tf
+++ b/modules/macstadium_dhcp_server_2/dhcp-server.tf
@@ -1,0 +1,123 @@
+data "template_file" "dhcpd_install" {
+  template = "${file("${path.module}/install-dhcpd.sh")}"
+}
+
+data "template_file" "dhcpd_conf" {
+  template = "${file("${path.module}/dhcpd.conf.tpl")}"
+
+  vars {
+    # this is the jobs subnet. really all this does is lop the /18 off of the var
+    jobs_subnet = "${cidrhost(var.jobs_network_subnet, 0)}"
+
+    # dhcpd takes netmask in decimal form
+    jobs_subnet_netmask = "${cidrnetmask(var.jobs_network_subnet)}"
+    domain_name         = "macstadium.travisci.net"
+
+    # we reserve the first 256 addresses of the subnet for ourselves. greedy
+    jobs_subnet_begin = "${cidrhost(var.jobs_network_subnet, 256)}"
+
+    # ...and the last 128, just in case.
+    jobs_subnet_end = "${cidrhost(var.jobs_network_subnet, -128)}"
+
+    # we assume the first address is the gateway (for now, it is)
+    jobs_gateway = "${cidrhost(var.jobs_network_subnet, 1)}"
+
+    # lease times are in seconds
+    dhcp_lease_default_time = "600"
+    dhcp_lease_max_time     = "12600"
+  }
+}
+
+resource "vsphere_virtual_machine" "dhcp_server" {
+  name             = "new-dhcp-server-${var.index}"
+  folder           = "Internal VMs"
+  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus  = 2
+  memory    = 4096
+  guest_id  = "${data.vsphere_virtual_machine.vanilla_template.guest_id}"
+  scsi_type = "${data.vsphere_virtual_machine.vanilla_template.scsi_type}"
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.vanilla_template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.vanilla_template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.vanilla_template.disks.0.thin_provisioned}"
+  }
+
+  network_interface {
+    network_id = "${data.vsphere_network.internal.id}"
+  }
+
+  network_interface {
+    network_id     = "${data.vsphere_network.jobs.id}"
+    use_static_mac = true
+    mac_address    = "${var.mac_address}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.vanilla_template.id}"
+
+    customize {
+      network_interface {
+        ipv4_address = "${cidrhost("10.182.64.0/18", 50 + var.index)}"
+        ipv4_netmask = 18
+      }
+
+      network_interface {
+        ipv4_address = "${cidrhost(var.jobs_network_subnet, 10)}"
+        ipv4_netmask = 18
+      }
+
+      linux_options {
+        host_name = "dhcp-server-${var.index}"
+        domain    = "macstadium-us-se-1.travisci.net"
+      }
+
+      ipv4_gateway    = "10.182.64.1"
+      dns_server_list = ["1.1.1.1", "1.0.0.1"]
+      dns_suffix_list = ["vsphere.local"]
+    }
+  }
+
+  wait_for_guest_net_routable = false
+
+  connection {
+    host  = "${self.clone.0.customize.0.network_interface.0.ipv4_address}"
+    user  = "${var.ssh_user}"
+    agent = true
+  }
+}
+
+resource "null_resource" "dhcp_server" {
+  triggers {
+    install_script_signature = "${sha256(data.template_file.dhcpd_install.rendered)}"
+    dhcpd_conf_signature     = "${sha256(data.template_file.dhcpd_conf.rendered)}"
+    jobs_network_subnet      = "${var.jobs_network_subnet}"
+    host_id                  = "${vsphere_virtual_machine.dhcp_server.id}"
+  }
+
+  connection {
+    host  = "${vsphere_virtual_machine.dhcp_server.clone.0.customize.0.network_interface.0.ipv4_address}"
+    user  = "${var.ssh_user}"
+    agent = true
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.dhcpd_conf.rendered}"
+    destination = "/tmp/dhcpd.conf"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["${data.template_file.dhcpd_install.rendered}"]
+  }
+}
+
+resource "aws_route53_record" "nodes" {
+  zone_id = "${var.travisci_net_external_zone_id}"
+  name    = "dhcp-server-${var.index}.macstadium-us-se-1.travisci.net"
+  type    = "A"
+  ttl     = 300
+  records = ["${vsphere_virtual_machine.dhcp_server.clone.0.customize.0.network_interface.0.ipv4_address}"]
+}

--- a/modules/macstadium_dhcp_server_2/dhcpd.conf.tpl
+++ b/modules/macstadium_dhcp_server_2/dhcpd.conf.tpl
@@ -1,0 +1,8 @@
+subnet ${jobs_subnet} netmask ${jobs_subnet_netmask} {
+  option domain-name "${domain_name}";
+  range ${jobs_subnet_begin} ${jobs_subnet_end};
+  option routers ${jobs_gateway};
+  option domain-name-servers 1.1.1.1, 1.0.0.1;
+  default-lease-time ${dhcp_lease_default_time};
+  max-lease-time ${dhcp_lease_max_time};
+}

--- a/modules/macstadium_dhcp_server_2/install-dhcpd.sh
+++ b/modules/macstadium_dhcp_server_2/install-dhcpd.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+
+main() {
+  #grab the dhcp server package
+  sudo yum install -y dhcp
+
+  # Configure dhcpd
+  sudo mv "/tmp/dhcpd.conf" "/etc/dhcp/dhcpd.conf"
+
+  # Start and enable the service
+  sudo systemctl enable dhcpd
+  sudo systemctl start dhcpd
+}
+
+main "$@"

--- a/modules/macstadium_dhcp_server_2/variables.tf
+++ b/modules/macstadium_dhcp_server_2/variables.tf
@@ -1,0 +1,41 @@
+variable "index" {}
+
+variable "datacenter" {
+  description = "The name of the vCenter datacenter that will run the created VMs"
+}
+
+variable "cluster" {
+  description = "The vCenter compute cluster that should run the created VMs"
+}
+
+variable "datastore" {
+  description = "The VMWare datastore that should hold the VM disks and configuration"
+}
+
+variable "internal_network_label" {
+  description = "The label for the internal network for the MacStadium VPN"
+}
+
+variable "jobs_network_label" {
+  description = "The label for the jobs network for the MacStadium VPN"
+}
+
+variable "jobs_network_subnet" {
+  description = "The subnet for the jobs network where this cluster is running"
+}
+
+variable "mac_address" {
+  description = "The MAC address assigned to the DHCP server VM on the jobs network"
+}
+
+variable "vanilla_image" {
+  default = "travis-ci-centos7-internal-vanilla-1549473064"
+}
+
+variable "travisci_net_external_zone_id" {
+  description = "The zone ID for the travisci.net DNS zone"
+}
+
+variable "ssh_user" {
+  description = "your SSH username on our vanilla Linux images"
+}

--- a/modules/macstadium_dhcp_server_2/vsphere.tf
+++ b/modules/macstadium_dhcp_server_2/vsphere.tf
@@ -1,0 +1,28 @@
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = "${var.cluster}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "internal" {
+  name          = "${var.internal_network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "jobs" {
+  name          = "${var.jobs_network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "vanilla_template" {
+  name          = "Vanilla VMs/${var.vanilla_image}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

* The DHCP server for job VMs is one thing we will want to keep running on its own VM even after everything else migrates to Kubernetes. However, we will need to be able to deploy it in the newer version of Terraform that we are using for the cluster VMs
* The `isc-dhcp-server` package in Trusty that we are currently running has a bug where it can never rotate its `dhcpd.leases` lease database because the database is owned by root. Xenial+ or other Linux distros do not have this problem in their package of this server.

## What approach did you choose and why?

I created a new module `macstadium_dhcp_server_2` (to avoid disruption of the existing DHCP server on pod-2) that will deploy both the VM and the configuration for a new DHCP server in Terraform v0.11. It's based on CentOS 7, and I've verified that it handles the permissions for its database correctly, so it should fix that bug.

The idea would be to deploy this VM, and for a few minutes have overlapping DHCP servers, then stop the service for the old one. We can't destroy the VM yet, since it's created by the `macstadium_infrastructure` module and that is still currently in use by `macstadium-prod-2`.

## How can you test this?

I brought up the VM already, and I ran the new dhcp server for a few seconds before turning it off. Logs from `journalctl -u dhcpd` suggest it was operating as expected. I also manually inspected the `dhcpd.conf` that was deployed.

## What feedback would you like, if any?

Any.