### PR TITLE
Use google-beta on gc_instance_group_manager.net

### DIFF
--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -49,7 +49,7 @@ terraform {
   }
 }
 
-provider "google" {
+provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
 }

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -368,14 +368,18 @@ resource "google_compute_firewall" "allow_nat_health_check" {
 }
 
 resource "google_compute_instance_group_manager" "nat" {
-  count = "${length(var.nat_zones) * var.nat_count_per_zone}"
+  provider = "google-beta"
+  count    = "${length(var.nat_zones) * var.nat_count_per_zone}"
 
   base_instance_name = "${var.env}-${var.index}-nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
-  instance_template  = "${element(google_compute_instance_template.nat.*.self_link, count.index)}"
   name               = "nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
   target_size        = 1
-  update_strategy    = "NONE"
   zone               = "${var.region}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}"
+
+  version {
+    name              = "${var.env}-${var.index}-nat-default"
+    instance_template = "${element(google_compute_instance_template.nat.*.self_link, count.index)}"
+  }
 
   named_port {
     name = "http"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

This resolves an error when trying to (re-)create the bastion host in gce-staging-net-1:

> Error: module.gce_net.google_compute_instance_group_manager.nat[3]: "auto_healing_policies.0.initial_delay_sec": [REMOVED] This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.

## What approach did you choose and why?

Introduce the `google-beta` provider, it works just like the `google` provider but you can set a `google-beta` on specific resource to use new features.

https://www.terraform.io/docs/providers/google/provider_versions.html#using-the-google-beta-provider

## How can you test this?

Executed against gce-staging-net-1.

## What feedback would you like, if any?

Should we prevent using `google-beta`? If so, which solution do you propose?
