### PR TITLE
Small fixes to make this repo easier to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ graph.png
 local-development-0/local-development-0.tfstate
 macstadium-*/config/
 tfstate
+.cache/
+config/
+.bundle/
+vendor/

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -28,7 +28,7 @@ variable "syslog_address_org" {}
 variable "worker_docker_self_image" {}
 
 variable "worker_image" {
-  default = "ubuntu-os-cloud/ubuntu-1804-lts"
+  default = "projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts"
 }
 
 variable "zones" {

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -258,6 +258,7 @@ resource "google_compute_instance_template" "worker_com" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["metadata.user-data"]
   }
 }
 
@@ -359,6 +360,7 @@ resource "google_compute_instance_template" "worker_com_free" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["metadata.user-data"]
   }
 }
 
@@ -460,6 +462,7 @@ resource "google_compute_instance_template" "worker_org" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["metadata.user-data"]
   }
 }
 

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -60,7 +60,7 @@ variable "worker_docker_self_image" {
 }
 
 variable "worker_image" {
-  default = "ubuntu-os-cloud/ubuntu-1804-lts"
+  default = "projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts"
 }
 
 variable "worker_managed_instance_count_com" {

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -16,8 +16,8 @@ AMQP_URL_ORG_VARNAME ?= AMQP_URL
 TOP := $(shell git rev-parse --show-toplevel)
 NATBZ2 := $(TOP)/assets/nat.tar.bz2
 
-PROD_TF_VERSION := v0.11.10
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
+PROD_TF_VERSION := v0.11.13
+TERRAFORM := $(TF_INSTALLATION_PREFIX)/terraform-$(PROD_TF_VERSION)
 
 export PROD_TF_VERSION
 export TERRAFORM


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`make plan` returned changesets for gce_workers as user-data got changed, usually user-data is only changed for when setting up new machines not already running machines. IMO we should not have too much user-data scripts, I believe this can better be handled by configuration management.

The `worker_image` name is different then set on the machines itself, this syncs that to what is actually on GCE.

Also, hitch-hiking a fix for the Makefile as I like to keep this setup isolated from my own installation. I've put the terraform installation in a different location, this was partially handled by `$TF_INSTALLATION_PREFIX` but not yet reflected in the Makefile.

Last change, I've put a few extra dirs in `.gitignore` that showed up as changed but are actually runtime files for terraform or ruby.

## What approach did you choose and why?

These changes should limit the plan/diff output from terraform and make it generally easier to use it.

## How can you test this?

Run it against gce-staging-1 (plan/apply) and against gce-production-1 (plan).

## What feedback would you like, if any?

Any feedback is welcome.