### PR TITLE
Name gke cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ graph.png
 local-development-0/local-development-0.tfstate
 macstadium-*/config/
 tfstate
+.cache/
+config/
+.bundle/
+vendor/

--- a/gce-staging-1/Makefile
+++ b/gce-staging-1/Makefile
@@ -3,10 +3,11 @@ TRAVIS_BUILD_ORG_HOST := build-staging.travis-ci.org
 JOB_BOARD_HOST := job-board-staging.travis-ci.com
 AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
 AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
+GKE_CLUSTER_NAME ?= gce-staging-1
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
 
 .PHONY: context
 context:
-	gcloud container clusters get-credentials cluster --zone us-central1-a --project travis-staging-1
-	kubectl config set-context gke_travis-staging-1_us-central1-a_cluster --namespace=gce-staging-1
+	gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone us-central1-a --project travis-staging-1
+	kubectl config set-context gke_travis-staging-1_us-central1-a_${GKE_CLUSTER_NAME} --namespace=gce-staging-1

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -158,6 +158,7 @@ EOF
 
 module "gke_staging_cluster_1" {
   source = "../modules/gke_cluster"
+  name   = "gce-staging-1"
 }
 
 output "workers_service_account_emails" {

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -28,7 +28,7 @@ variable "syslog_address_org" {}
 variable "worker_docker_self_image" {}
 
 variable "worker_image" {
-  default = "ubuntu-os-cloud/ubuntu-1804-lts"
+  default = "projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts"
 }
 
 variable "zones" {

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -258,6 +258,7 @@ resource "google_compute_instance_template" "worker_com" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["metadata.user-data"]
   }
 }
 
@@ -359,6 +360,7 @@ resource "google_compute_instance_template" "worker_com_free" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["metadata.user-data"]
   }
 }
 
@@ -460,6 +462,7 @@ resource "google_compute_instance_template" "worker_org" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["metadata.user-data"]
   }
 }
 

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -60,7 +60,7 @@ variable "worker_docker_self_image" {
 }
 
 variable "worker_image" {
-  default = "ubuntu-os-cloud/ubuntu-1804-lts"
+  default = "projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts"
 }
 
 variable "worker_managed_instance_count_com" {

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -16,8 +16,8 @@ AMQP_URL_ORG_VARNAME ?= AMQP_URL
 TOP := $(shell git rev-parse --show-toplevel)
 NATBZ2 := $(TOP)/assets/nat.tar.bz2
 
-PROD_TF_VERSION := v0.11.10
-TERRAFORM := $(HOME)/.cache/travis-terraform-config/terraform-$(PROD_TF_VERSION)
+PROD_TF_VERSION := v0.11.13
+TERRAFORM := $(TF_INSTALLATION_PREFIX)/terraform-$(PROD_TF_VERSION)
 
 export PROD_TF_VERSION
 export TERRAFORM


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

I've named the cluster `gce-staging-1` instead of keeping the cluster name `cluster`, which is just silly.

## What approach did you choose and why?

I added the variable `name` to the module, it makes sense to configure this in main.tf of the environment.
This also changes the cluster name in the Makefile, we probably want to take a more general approach here, in mean time this should suffice.

## How can you test this?

Deployed in staging.

## What feedback would you like, if any?

Any would be great. ;-)

Note: I've included the changes from https://github.com/travis-ci/terraform-config/pull/667 here, I believe these changes are sensible.
