### PR TITLE
Allow GKE cluster to access Redis instance

### DIFF
--- a/gce-production-1/Makefile
+++ b/gce-production-1/Makefile
@@ -1,7 +1,7 @@
 AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
 AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 GCE_PROJECT := eco-emissary-99515
-GKE_CLUSTER_NAME := gce-production-1
+GKE_CLUSTER_NAME := gce-production-1-vpc-enabled
 GKE_CLUSTER_ZONE := us-central1-a
 
 include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -167,9 +167,9 @@ export AWS_SECRET_ACCESS_KEY=${module.aws_iam_user_s3_org.secret}
 EOF
 }
 
-module "gke_cluster_1" {
+module "gke_cluster_2" {
   source         = "../modules/gke_cluster"
-  name           = "gce-production-1"
+  name           = "gce-production-1-vpc-enabled"
   gke_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
   gke_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
 }

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -168,8 +168,10 @@ EOF
 }
 
 module "gke_cluster_1" {
-  source = "../modules/gke_cluster"
-  name   = "gce-production-1"
+  source         = "../modules/gke_cluster"
+  name           = "gce-production-1"
+  gke_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
+  gke_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
 }
 
 resource "google_project_iam_member" "staging_1_workers" {

--- a/gce-production-net-1/main.tf
+++ b/gce-production-net-1/main.tf
@@ -139,6 +139,14 @@ resource "google_compute_firewall" "allow_winrm_to_packer_templates_builds" {
   target_tags   = ["travis-ci-packer-templates"]
 }
 
+output "gce_network_main" {
+  value = "${module.gce_net.gce_network_main}"
+}
+
 output "gce_subnetwork_workers" {
   value = "${module.gce_net.gce_subnetwork_workers}"
+}
+
+output "gce_subnetwork_gke_cluster" {
+  value = "${module.gce_net.gce_subnetwork_gke_cluster}"
 }

--- a/gce-production-net-1/main.tf
+++ b/gce-production-net-1/main.tf
@@ -54,7 +54,7 @@ terraform {
   }
 }
 
-provider "google" {
+provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
 }

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -157,8 +157,10 @@ EOF
 }
 
 module "gke_cluster_1" {
-  source = "../modules/gke_cluster"
-  name   = "gce-staging-1"
+  source         = "../modules/gke_cluster"
+  name           = "gce-staging-1"
+  gke_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
+  gke_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
 }
 
 output "workers_service_account_emails" {

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -174,3 +174,7 @@ output "warmer_service_account_emails" {
 output "latest_docker_image_worker" {
   value = "${var.latest_docker_image_worker}"
 }
+
+output "redis_worker_rate_limit" {
+  value = "${module.gce_worker_group.redis_worker_rate_limit}"
+}

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -88,6 +88,14 @@ module "gce_net" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
 }
 
+output "gce_network_main" {
+  value = "${module.gce_net.gce_network_main}"
+}
+
 output "gce_subnetwork_workers" {
   value = "${module.gce_net.gce_subnetwork_workers}"
+}
+
+output "gce_subnetwork_gke_cluster" {
+  value = "${module.gce_net.gce_subnetwork_gke_cluster}"
 }

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -49,7 +49,7 @@ terraform {
   }
 }
 
-provider "google" {
+provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
 }

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -87,6 +87,10 @@ variable "jobs_com_subnet_cidr_range" {
   default = "10.30.0.0/16"
 }
 
+variable "gke_cluster_subnet_cidr_range" {
+  default = "10.40.0.0/16"
+}
+
 variable "build_com_subnet_cidr_range" {
   default = "10.10.12.0/22"
 }
@@ -131,6 +135,15 @@ resource "google_compute_subnetwork" "jobs_org" {
 resource "google_compute_subnetwork" "jobs_com" {
   name             = "jobs-com"
   ip_cidr_range    = "${var.jobs_com_subnet_cidr_range}"
+  network          = "${google_compute_network.main.self_link}"
+  region           = "${var.region}"
+  project          = "${var.project}"
+  enable_flow_logs = "true"
+}
+
+resource "google_compute_subnetwork" "gke_cluster" {
+  name             = "gke-cluster"
+  ip_cidr_range    = "${var.gke_cluster_subnet_cidr_range}"
   network          = "${google_compute_network.main.self_link}"
   region           = "${var.region}"
   project          = "${var.project}"
@@ -184,6 +197,7 @@ resource "google_compute_firewall" "allow_internal" {
   source_ranges = [
     "${google_compute_subnetwork.public.ip_cidr_range}",
     "${google_compute_subnetwork.workers.ip_cidr_range}",
+    "${google_compute_subnetwork.gke_cluster.ip_cidr_range}",
   ]
 
   allow {
@@ -524,10 +538,18 @@ resource "google_compute_instance" "bastion" {
   }
 }
 
+output "gce_network_main" {
+  value = "${google_compute_network.main.self_link}"
+}
+
 output "gce_subnetwork_public" {
   value = "${google_compute_subnetwork.public.self_link}"
 }
 
 output "gce_subnetwork_workers" {
   value = "${google_compute_subnetwork.workers.self_link}"
+}
+
+output "gce_subnetwork_gke_cluster" {
+  value = "${google_compute_subnetwork.gke_cluster.self_link}"
 }

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -368,14 +368,18 @@ resource "google_compute_firewall" "allow_nat_health_check" {
 }
 
 resource "google_compute_instance_group_manager" "nat" {
-  count = "${length(var.nat_zones) * var.nat_count_per_zone}"
+  provider = "google-beta"
+  count    = "${length(var.nat_zones) * var.nat_count_per_zone}"
 
   base_instance_name = "${var.env}-${var.index}-nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
-  instance_template  = "${element(google_compute_instance_template.nat.*.self_link, count.index)}"
   name               = "nat-${element(var.nat_zones, count.index / var.nat_count_per_zone)}-${(count.index % var.nat_count_per_zone) + 1}"
   target_size        = 1
-  update_strategy    = "NONE"
   zone               = "${var.region}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}"
+
+  version {
+    name              = "${var.env}-${var.index}-nat-default"
+    instance_template = "${element(google_compute_instance_template.nat.*.self_link, count.index)}"
+  }
 
   named_port {
     name = "http"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -286,7 +286,7 @@ data "template_file" "nat_cloud_config" {
   template = "${file("${path.module}/nat-cloud-config.yml.tpl")}"
 
   vars {
-    assets          = "${path.module}/../../assets"
+    assets          = "${path.module}/../../../../assets"
     cloud_init_bash = "${file("${path.module}/nat-cloud-init.bash")}"
     nat_config      = "${var.nat_config}"
     syslog_address  = "${var.syslog_address}"

--- a/modules/gce_net/nat-cloud-config.yml.tpl
+++ b/modules/gce_net/nat-cloud-config.yml.tpl
@@ -22,7 +22,7 @@ write_files:
   encoding: b64
   path: /var/lib/cloud/scripts/per-boot/99-nat-cloud-init
   permissions: '0750'
-- content: '${base64encode(file("${assets}/nat.tar.bz2"))}'
+- content: '${filebase64("${assets}/nat.tar.bz2")}'
   encoding: b64
   path: /var/tmp/nat.tar.bz2
 - content: '${base64encode(syslog_address)}'

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -506,3 +506,7 @@ output "workers_service_account_names" {
     "${google_service_account.workers_com_free.name}",
   ]
 }
+
+output "redis_worker_rate_limit" {
+  value = "redis://${google_redis_instance.worker_rate_limit.host}:${google_redis_instance.worker_rate_limit.port}"
+}

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -266,3 +266,7 @@ output "workers_service_account_names" {
 output "warmer_service_account_emails" {
   value = ["${module.warmer.service_account_emails}"]
 }
+
+output "redis_worker_rate_limit" {
+  value = "${module.gce_workers.redis_worker_rate_limit}"
+}

--- a/modules/gke_cluster/gke.tf
+++ b/modules/gke_cluster/gke.tf
@@ -6,12 +6,24 @@ variable "zone" {
   default = "us-central1-a"
 }
 
+variable "gke_network" {
+  default = "default"
+}
+
+variable "gke_subnetwork" {
+  default = "default"
+}
+
 resource "google_container_cluster" "gke_cluster" {
   name                     = "${var.name}"
   zone                     = "${var.zone}"
   min_master_version       = "1.11"
   initial_node_count       = 1
   remove_default_node_pool = true
+  network                  = "${var.gke_network}"
+  subnetwork               = "${var.gke_subnetwork}"
+
+  ip_allocation_policy {}
 
   master_auth {
     client_certificate_config {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The GKE cluster needs to be able to access the worker-rate-limit Redis instance.

## What approach did you choose and why?
I implemented this in Terraform: 
https://cloud.google.com/memorystore/docs/redis/connecting-redis-instance
TL;DR: Add to 'main' network and create subnet + turn on IP aliasing.

## How can you test this?
I deployed it on staging, then ran the `telnet` command as mentioned.

## What feedback would you like, if any?
I'm not a network expert so there are a bunch of hidden assumption here as I copy/paste a subnet here. Please have a look.
