### PR TITLE
Increase NATs on GCE prod-2

### DIFF
--- a/gce-production-net-2/main.tf
+++ b/gce-production-net-2/main.tf
@@ -77,7 +77,7 @@ module "gce_net" {
   nat_conntracker_config        = "${file("nat-conntracker.env")}"
   nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
   nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
-  nat_count_per_zone            = 1
+  nat_count_per_zone            = 2
   nat_image                     = "${var.gce_nat_image}"
   nat_machine_type              = "n1-standard-4"
   project                       = "${var.project}"

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -81,7 +81,7 @@ module "gce_net" {
   nat_conntracker_config        = "${file("nat-conntracker.env")}"
   nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
   nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
-  nat_count_per_zone            = 1
+  nat_count_per_zone            = 2
   nat_image                     = "${var.gce_nat_image}"
   nat_machine_type              = "g1-small"
   project                       = "${var.project}"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -160,6 +160,10 @@ resource "google_compute_firewall" "allow_main_ssh" {
     protocol = "tcp"
     ports    = [22]
   }
+
+  lifecycle {
+    ignore_changes = ["source_ranges"]
+  }
 }
 
 resource "google_compute_firewall" "allow_public_ssh" {
@@ -428,6 +432,7 @@ resource "google_compute_route" "nat" {
   next_hop_instance_zone = "${var.region}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}"
   priority               = 800
   tags                   = ["no-ip"]
+  project                = "${var.project}"
 
   lifecycle {
     # NOTE: the `next_hop_instance` is provided by `data.external.nats_by_zone`,

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -101,23 +101,9 @@ module "warmer" {
 module "gce_workers" {
   source = "../gce_worker"
 
-  config_com = <<EOF
-${var.worker_config_com}
-
-export TRAVIS_WORKER_WARMER_URL=https://travis-worker-${var.env}-${var.index}-com:${module.warmer.auth_token}@${module.warmer.app_hostname}
-EOF
-
-  config_com_free = <<EOF
-${var.worker_config_com_free}
-
-export TRAVIS_WORKER_WARMER_URL=https://travis-worker-${var.env}-${var.index}-com-free:${module.warmer.auth_token}@${module.warmer.app_hostname}
-EOF
-
-  config_org = <<EOF
-${var.worker_config_org}
-
-export TRAVIS_WORKER_WARMER_URL=https://travis-worker-${var.env}-${var.index}-org:${module.warmer.auth_token}@${module.warmer.app_hostname}
-EOF
+  config_com      = "${var.worker_config_com}"
+  config_com_free = "${var.worker_config_com_free}"
+  config_org      = "${var.worker_config_org}"
 
   env          = "${var.env}"
   github_users = "${var.github_users}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The NATs on production-2 are likely saturated, it is believed they are the cause network latency on the jobs is bad. To resolve this, we need to increase the number of NATs per zone.

## What approach did you choose and why?
To limit/mitigate the amount of downtime and prevent the hurdle of cycling all the NATs, I've refactored the configuration a bit so we can add more NATs without touching the existing NATs.

## How can you test this?
I have tested this on staging.

## What feedback would you like, if any?
Not really.

Side notes:
- After creating the extra NATs, we should plan for cycling the existing NATs on production-2 so they use the same template.
- The NATs on production-1 need cycling/updating too, but that is less urgent.
