### PR TITLE
Remove unused apps from the configuration

### DIFF
--- a/bin/gce-export-workers
+++ b/bin/gce-export-workers
@@ -48,7 +48,6 @@ def main
   zones = options.fetch(:zones)
 
   command = %W[#{terraform} state rm]
-  command << "module.#{module_name}.heroku_app.gcloud_cleanup"
 
   %i[com org].each do |site|
     zones.each do |zone|

--- a/bin/gce-import-workers
+++ b/bin/gce-import-workers
@@ -71,9 +71,7 @@ def main
   terraform = options.fetch(:terraform)
   zones = options.fetch(:zones)
 
-  to_import = {
-    'heroku_app.gcloud_cleanup' => "gcloud-cleanup-#{env}-#{index}"
-  }
+  to_import = {}
 
   %i[com org].each do |site|
     counts.fetch(site).times do |n|

--- a/gce-production-1/instance-counts.auto.tfvars
+++ b/gce-production-1/instance-counts.auto.tfvars
@@ -1,5 +1,5 @@
 {
-  "worker_managed_instance_count_com": 35,
-  "worker_managed_instance_count_org": 45,
+  "worker_managed_instance_count_com": 40,
+  "worker_managed_instance_count_org": 30,
   "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -23,8 +23,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "warmer_honeycomb_write_key" {}
-
 variable "worker_managed_instance_count_com" {}
 variable "worker_managed_instance_count_org" {}
 variable "worker_managed_instance_count_com_free" {}
@@ -100,7 +98,6 @@ module "gce_worker_group" {
   env                           = "${var.env}"
   github_users                  = "${var.github_users}"
   heroku_org                    = "${var.gce_heroku_org}"
-  honeycomb_key                 = "${var.warmer_honeycomb_write_key}"
   index                         = "${var.index}"
   project                       = "${var.project}"
   region                        = "us-central1"

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -3,7 +3,6 @@ variable "env" {
 }
 
 variable "gce_heroku_org" {}
-
 variable "github_users" {}
 
 variable "index" {
@@ -51,28 +50,6 @@ data "terraform_remote_state" "vpc" {
   config {
     bucket         = "travis-terraform-state"
     key            = "terraform-config/gce-production-net-1.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "travis-terraform-state"
-  }
-}
-
-data "terraform_remote_state" "staging_1" {
-  backend = "s3"
-
-  config {
-    bucket         = "travis-terraform-state"
-    key            = "terraform-config/gce-staging-1.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "travis-terraform-state"
-  }
-}
-
-data "terraform_remote_state" "production_2" {
-  backend = "s3"
-
-  config {
-    bucket         = "travis-terraform-state"
-    key            = "terraform-config/gce-production-2.tfstate"
     region         = "us-east-1"
     dynamodb_table = "travis-terraform-state"
   }
@@ -169,16 +146,10 @@ module "gke_cluster_2" {
   region = "us-central1-a"
 }
 
-resource "google_project_iam_member" "staging_1_workers" {
-  count   = "${length(data.terraform_remote_state.staging_1.workers_service_account_emails)}"
-  project = "${var.project}"
-  role    = "roles/compute.imageUser"
-  member  = "serviceAccount:${element(data.terraform_remote_state.staging_1.workers_service_account_emails, count.index)}"
+output "workers_service_account_emails" {
+  value = ["${module.gce_worker_group.workers_service_account_emails}"]
 }
 
-resource "google_project_iam_member" "production_2_workers" {
-  count   = "${length(data.terraform_remote_state.production_2.workers_service_account_emails)}"
-  project = "${var.project}"
-  role    = "roles/compute.imageUser"
-  member  = "serviceAccount:${element(data.terraform_remote_state.production_2.workers_service_account_emails, count.index)}"
+output "gcloud_cleanup_account_json" {
+  value = "${module.gce_worker_group.gcloud_cleanup_account_json}"
 }

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -2,7 +2,6 @@ variable "env" {
   default = "production"
 }
 
-variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "github_users" {}
@@ -98,20 +97,16 @@ module "aws_iam_user_s3_org" {
 module "gce_worker_group" {
   source = "../modules/gce_worker_group"
 
-  env                                       = "${var.env}"
-  gcloud_cleanup_job_board_url              = "${var.job_board_url}"
-  gcloud_cleanup_opencensus_sampling_rate   = "10"
-  gcloud_cleanup_opencensus_tracing_enabled = "true"
-  gcloud_zone                               = "${var.gce_gcloud_zone}"
-  github_users                              = "${var.github_users}"
-  heroku_org                                = "${var.gce_heroku_org}"
-  honeycomb_key                             = "${var.warmer_honeycomb_write_key}"
-  index                                     = "${var.index}"
-  project                                   = "${var.project}"
-  region                                    = "us-central1"
-  syslog_address_com                        = "${var.syslog_address_com}"
-  syslog_address_org                        = "${var.syslog_address_org}"
-  travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
+  env                           = "${var.env}"
+  github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
+  honeycomb_key                 = "${var.warmer_honeycomb_write_key}"
+  index                         = "${var.index}"
+  project                       = "${var.project}"
+  region                        = "us-central1"
+  syslog_address_com            = "${var.syslog_address_com}"
+  syslog_address_org            = "${var.syslog_address_org}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
 
   worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 

--- a/gce-production-1/service_accounts.tf
+++ b/gce-production-1/service_accounts.tf
@@ -1,0 +1,35 @@
+data "terraform_remote_state" "staging_1" {
+  backend = "s3"
+
+  config {
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-staging-1.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "travis-terraform-state"
+  }
+}
+
+data "terraform_remote_state" "production_2" {
+  backend = "s3"
+
+  config {
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-2.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "travis-terraform-state"
+  }
+}
+
+resource "google_project_iam_member" "staging_1_workers" {
+  count   = "${length(data.terraform_remote_state.staging_1.workers_service_account_emails)}"
+  project = "${var.project}"
+  role    = "roles/compute.imageUser"
+  member  = "serviceAccount:${element(data.terraform_remote_state.staging_1.workers_service_account_emails, count.index)}"
+}
+
+resource "google_project_iam_member" "production_2_workers" {
+  count   = "${length(data.terraform_remote_state.production_2.workers_service_account_emails)}"
+  project = "${var.project}"
+  role    = "roles/compute.imageUser"
+  member  = "serviceAccount:${element(data.terraform_remote_state.production_2.workers_service_account_emails, count.index)}"
+}

--- a/gce-production-2/Makefile
+++ b/gce-production-2/Makefile
@@ -1,4 +1,7 @@
 AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
 AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
+GCE_PROJECT := travis-ci-prod-2
+GKE_CLUSTER_NAME := gce-production-2
+GKE_CLUSTER_ZONE := us-central1
 
 include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-2/instance-counts.auto.tfvars
+++ b/gce-production-2/instance-counts.auto.tfvars
@@ -1,5 +1,5 @@
 {
-  "worker_managed_instance_count_com": 45,
-  "worker_managed_instance_count_org": 9,
+  "worker_managed_instance_count_com": 25,
+  "worker_managed_instance_count_org": 5,
   "worker_managed_instance_count_com_free": 0
 }

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -3,7 +3,6 @@ variable "env" {
 }
 
 variable "gce_heroku_org" {}
-
 variable "github_users" {}
 
 variable "index" {
@@ -146,4 +145,8 @@ module "gke_cluster_1" {
 
 output "workers_service_account_emails" {
   value = ["${module.gce_worker_group.workers_service_account_emails}"]
+}
+
+output "gcloud_cleanup_account_json" {
+  value = "${module.gce_worker_group.gcloud_cleanup_account_json}"
 }

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -2,7 +2,6 @@ variable "env" {
   default = "production"
 }
 
-variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "github_users" {}
@@ -76,20 +75,16 @@ module "aws_iam_user_s3_org" {
 module "gce_worker_group" {
   source = "../modules/gce_worker_group"
 
-  env                                       = "${var.env}"
-  gcloud_cleanup_job_board_url              = "${var.job_board_url}"
-  gcloud_cleanup_opencensus_sampling_rate   = "10"
-  gcloud_cleanup_opencensus_tracing_enabled = "true"
-  gcloud_zone                               = "${var.gce_gcloud_zone}"
-  github_users                              = "${var.github_users}"
-  heroku_org                                = "${var.gce_heroku_org}"
-  honeycomb_key                             = "${var.warmer_honeycomb_write_key}"
-  index                                     = "${var.index}"
-  project                                   = "${var.project}"
-  region                                    = "us-central1"
-  syslog_address_com                        = "${var.syslog_address_com}"
-  syslog_address_org                        = "${var.syslog_address_org}"
-  travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
+  env                           = "${var.env}"
+  github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
+  honeycomb_key                 = "${var.warmer_honeycomb_write_key}"
+  index                         = "${var.index}"
+  project                       = "${var.project}"
+  region                        = "us-central1"
+  syslog_address_com            = "${var.syslog_address_com}"
+  syslog_address_org            = "${var.syslog_address_org}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
 
   worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -137,6 +137,13 @@ export AWS_SECRET_ACCESS_KEY=${module.aws_iam_user_s3_org.secret}
 EOF
 }
 
+module "gke_cluster_1" {
+  source         = "../modules/gke_cluster"
+  name           = "gce-production-2"
+  gke_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
+  gke_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
+}
+
 output "workers_service_account_emails" {
   value = ["${module.gce_worker_group.workers_service_account_emails}"]
 }

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -23,8 +23,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "warmer_honeycomb_write_key" {}
-
 variable "worker_managed_instance_count_com" {}
 variable "worker_managed_instance_count_org" {}
 variable "worker_managed_instance_count_com_free" {}
@@ -78,7 +76,6 @@ module "gce_worker_group" {
   env                           = "${var.env}"
   github_users                  = "${var.github_users}"
   heroku_org                    = "${var.gce_heroku_org}"
-  honeycomb_key                 = "${var.warmer_honeycomb_write_key}"
   index                         = "${var.index}"
   project                       = "${var.project}"
   region                        = "us-central1"
@@ -142,8 +139,4 @@ EOF
 
 output "workers_service_account_emails" {
   value = ["${module.gce_worker_group.workers_service_account_emails}"]
-}
-
-output "warmer_service_account_emails" {
-  value = ["${module.gce_worker_group.warmer_service_account_emails}"]
 }

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -2,7 +2,6 @@ variable "env" {
   default = "production"
 }
 
-variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 
 variable "github_users" {}
@@ -74,20 +73,16 @@ module "aws_iam_user_s3_org" {
 module "gce_worker_group" {
   source = "../modules/gce_worker_group"
 
-  env                                       = "${var.env}"
-  gcloud_cleanup_job_board_url              = "${var.job_board_url}"
-  gcloud_cleanup_opencensus_sampling_rate   = "10"
-  gcloud_cleanup_opencensus_tracing_enabled = "true"
-  gcloud_zone                               = "${var.gce_gcloud_zone}"
-  github_users                              = "${var.github_users}"
-  heroku_org                                = "${var.gce_heroku_org}"
-  index                                     = "${var.index}"
-  project                                   = "${var.project}"
-  region                                    = "us-central1"
-  syslog_address_com                        = "${var.syslog_address_com}"
-  syslog_address_org                        = "${var.syslog_address_org}"
-  travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
-  worker_subnetwork                         = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
+  env                           = "${var.env}"
+  github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
+  index                         = "${var.index}"
+  project                       = "${var.project}"
+  region                        = "us-central1"
+  syslog_address_com            = "${var.syslog_address_com}"
+  syslog_address_org            = "${var.syslog_address_org}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+  worker_subnetwork             = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/gce-production-net-1/main.tf
+++ b/gce-production-net-1/main.tf
@@ -84,6 +84,19 @@ module "gce_net" {
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"
   syslog_address                = "${var.syslog_address_com}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+
+  # Legacy: nat_name order of prod-1 is different, see commit f279f65597
+  # Removing this would create new NAT IP addresses and should be done with care.
+  nat_names = [
+    "nat-a-1",
+    "nat-a-2",
+    "nat-b-1",
+    "nat-b-2",
+    "nat-c-1",
+    "nat-c-2",
+    "nat-f-1",
+    "nat-f-2",
+  ]
 }
 
 data "google_compute_network" "main" {

--- a/gce-production-net-2/main.tf
+++ b/gce-production-net-2/main.tf
@@ -88,6 +88,14 @@ module "gce_net" {
   workers_subnet_cidr_range     = "10.10.16.0/22"
 }
 
+output "gce_network_main" {
+  value = "${module.gce_net.gce_network_main}"
+}
+
 output "gce_subnetwork_workers" {
   value = "${module.gce_net.gce_subnetwork_workers}"
+}
+
+output "gce_subnetwork_gke_cluster" {
+  value = "${module.gce_net.gce_subnetwork_gke_cluster}"
 }

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -2,7 +2,6 @@ variable "env" {
   default = "staging"
 }
 
-variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 variable "github_users" {}
 
@@ -80,22 +79,16 @@ module "aws_iam_user_s3_org" {
 module "gce_worker_group" {
   source = "../modules/gce_worker_group"
 
-  env                                       = "${var.env}"
-  gcloud_cleanup_job_board_url              = "${var.job_board_url}"
-  gcloud_cleanup_loop_sleep                 = "2m"
-  gcloud_cleanup_scale                      = "worker=1:standard-1X"
-  gcloud_cleanup_opencensus_sampling_rate   = "4"
-  gcloud_cleanup_opencensus_tracing_enabled = "true"
-  gcloud_zone                               = "${var.gce_gcloud_zone}"
-  github_users                              = "${var.github_users}"
-  heroku_org                                = "${var.gce_heroku_org}"
-  honeycomb_key                             = "${var.warmer_honeycomb_write_key}"
-  index                                     = "${var.index}"
-  project                                   = "${var.project}"
-  region                                    = "us-central1"
-  syslog_address_com                        = "${var.syslog_address_com}"
-  syslog_address_org                        = "${var.syslog_address_org}"
-  travisci_net_external_zone_id             = "${var.travisci_net_external_zone_id}"
+  env                           = "${var.env}"
+  github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
+  honeycomb_key                 = "${var.warmer_honeycomb_write_key}"
+  index                         = "${var.index}"
+  project                       = "${var.project}"
+  region                        = "us-central1"
+  syslog_address_com            = "${var.syslog_address_com}"
+  syslog_address_org            = "${var.syslog_address_org}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
 
   warmer_version = "${var.warmer_version}"
 

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -23,12 +23,6 @@ variable "travisci_net_external_zone_id" {
   default = "Z2RI61YP4UWSIO"
 }
 
-variable "warmer_honeycomb_write_key" {}
-
-variable "warmer_version" {
-  default = "master"
-}
-
 variable "worker_zones" {
   default = ["a", "b", "c", "f"]
 }
@@ -82,15 +76,12 @@ module "gce_worker_group" {
   env                           = "${var.env}"
   github_users                  = "${var.github_users}"
   heroku_org                    = "${var.gce_heroku_org}"
-  honeycomb_key                 = "${var.warmer_honeycomb_write_key}"
   index                         = "${var.index}"
   project                       = "${var.project}"
   region                        = "us-central1"
   syslog_address_com            = "${var.syslog_address_com}"
   syslog_address_org            = "${var.syslog_address_org}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
-
-  warmer_version = "${var.warmer_version}"
 
   worker_docker_self_image = "${var.latest_docker_image_worker}"
   worker_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
@@ -161,10 +152,6 @@ module "gke_cluster_1" {
 
 output "workers_service_account_emails" {
   value = ["${module.gce_worker_group.workers_service_account_emails}"]
-}
-
-output "warmer_service_account_emails" {
-  value = ["${module.gce_worker_group.warmer_service_account_emails}"]
 }
 
 output "latest_docker_image_worker" {

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -158,6 +158,6 @@ output "latest_docker_image_worker" {
   value = "${var.latest_docker_image_worker}"
 }
 
-output "redis_worker_rate_limit" {
-  value = "${module.gce_worker_group.redis_worker_rate_limit}"
+output "gcloud_cleanup_account_json" {
+  value = "${module.gce_worker_group.gcloud_cleanup_account_json}"
 }

--- a/modules/gce_worker/main.tf
+++ b/modules/gce_worker/main.tf
@@ -258,7 +258,6 @@ resource "google_compute_instance_template" "worker_com" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = ["metadata.user-data"]
   }
 }
 
@@ -360,7 +359,6 @@ resource "google_compute_instance_template" "worker_com_free" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = ["metadata.user-data"]
   }
 }
 
@@ -462,7 +460,6 @@ resource "google_compute_instance_template" "worker_org" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = ["metadata.user-data"]
   }
 }
 

--- a/modules/gce_worker_group/main.tf
+++ b/modules/gce_worker_group/main.tf
@@ -6,21 +6,12 @@ variable "gcloud_cleanup_archive_retention_days" {
 
 variable "github_users" {}
 variable "heroku_org" {}
-variable "honeycomb_key" {}
 variable "index" {}
 variable "project" {}
 variable "region" {}
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 variable "travisci_net_external_zone_id" {}
-
-variable "warmer_scale" {
-  default = "web=1:Standard-1X checker=1:Standard-1X"
-}
-
-variable "warmer_version" {
-  default = "master"
-}
 
 variable "worker_config_com" {}
 variable "worker_config_com_free" {}
@@ -54,19 +45,6 @@ variable "worker_subnetwork" {}
 
 variable "worker_zones" {
   default = ["a", "b", "c", "f"]
-}
-
-module "warmer" {
-  source = "../warmer"
-
-  env           = "${var.env}"
-  heroku_org    = "${var.heroku_org}"
-  honeycomb_key = "${var.honeycomb_key}"
-  index         = "${var.index}"
-  project       = "${var.project}"
-  region        = "${var.region}"
-  app_scale     = "${var.warmer_scale}"
-  app_version   = "${var.warmer_version}"
 }
 
 module "gce_workers" {
@@ -176,10 +154,6 @@ output "workers_service_account_emails" {
 
 output "workers_service_account_names" {
   value = ["${module.gce_workers.workers_service_account_names}"]
-}
-
-output "warmer_service_account_emails" {
-  value = ["${module.warmer.service_account_emails}"]
 }
 
 output "redis_worker_rate_limit" {

--- a/modules/warmer/main.tf
+++ b/modules/warmer/main.tf
@@ -142,14 +142,16 @@ resource "heroku_app" "warmer" {
     HONEYCOMB_DATASET  = "warmer"
     MANAGED_VIA        = "github.com/travis-ci/terraform-config"
     RACK_ENV           = "${var.env}"
+    LANG               = "en_US.UTF-8"
 
-    WARMER_AUTH_TOKENS               = "${random_string.auth_token.result}"
-    WARMER_GOOGLE_CLOUD_KEYFILE_JSON = "${base64decode(google_service_account_key.warmer.private_key)}"
-    WARMER_GOOGLE_CLOUD_PROJECT      = "${var.project}"
-    WARMER_GOOGLE_CLOUD_REGION       = "${var.region}"
-    WARMER_ORPHAN_THRESHOLD          = 20
-    WARMER_POOL_CHECK_INTERVAL       = 30
-    WARMER_VM_CREATION_TIMEOUT       = 120
+    WARMER_AUTH_TOKENS                 = "${random_string.auth_token.result}"
+    WARMER_GOOGLE_CLOUD_KEYFILE_JSON   = "${base64decode(google_service_account_key.warmer.private_key)}"
+    WARMER_GOOGLE_CLOUD_PROJECT        = "${var.project}"
+    WARMER_GOOGLE_CLOUD_REGION         = "${var.region}"
+    WARMER_ORPHAN_THRESHOLD            = 20
+    WARMER_POOL_CHECK_INTERVAL         = 30
+    WARMER_CHECKER_POOL_CHECK_INTERVAL = 30
+    WARMER_VM_CREATION_TIMEOUT         = 120
   }
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

- gcloud-cleanup is running on kubernetes, no need to configure it with terraform anymore.
- warmer is not really being used right now, turning it of for now
- create a kubernetes cluster on prod-2, initially to host gcloud-cleanup
- order the nat_names differently on prod-1, see related commit f279f65

## What approach did you choose and why?

Remove configuration that is not actively used, less code = less bugs.

## How can you test this?

Run against staging.

## What feedback would you like, if any?

If you know more about warmer, I'd like to hear about it.
