### PR TITLE
Revive production-3

### DIFF
--- a/dns-production-0/main.tf
+++ b/dns-production-0/main.tf
@@ -54,6 +54,10 @@ data "dns_a_record_set" "gce_production_2_nat" {
   host = "nat-production-2.gce-us-central1.travisci.net"
 }
 
+data "dns_a_record_set" "gce_production_3_nat" {
+  host = "nat-production-3.gce-us-central1.travisci.net"
+}
+
 data "dns_a_record_set" "gce_production_1_build_cache" {
   host = "production-1-build-cache.gce-us-central1.travisci.net"
 }
@@ -71,6 +75,7 @@ resource "aws_route53_record" "gce_nat" {
   records = [
     "${data.dns_a_record_set.gce_production_1_nat.addrs}",
     "${data.dns_a_record_set.gce_production_2_nat.addrs}",
+    "${data.dns_a_record_set.gce_production_3_nat.addrs}",
   ]
 }
 
@@ -83,6 +88,7 @@ resource "aws_route53_record" "linux_containers_nat" {
   records = [
     "${data.dns_a_record_set.gce_production_1_nat.addrs}",
     "${data.dns_a_record_set.gce_production_2_nat.addrs}",
+    "${data.dns_a_record_set.gce_production_3_nat.addrs}",
   ]
 }
 
@@ -104,6 +110,7 @@ resource "aws_route53_record" "nat" {
   records = [
     "${data.dns_a_record_set.gce_production_1_nat.addrs}",
     "${data.dns_a_record_set.gce_production_2_nat.addrs}",
+    "${data.dns_a_record_set.gce_production_3_nat.addrs}",
     "${var.macstadium_production_nat_addrs}",
   ]
 }
@@ -139,6 +146,8 @@ resource "heroku_app" "whereami" {
       join(",", data.dns_a_record_set.gce_production_1_nat.addrs)
     },${
       join(",", data.dns_a_record_set.gce_production_2_nat.addrs)
+    },${
+      join(",", data.dns_a_record_set.gce_production_3_nat.addrs)
     }"
 
     WHEREAMI_INFRA_MACSTADIUM_IPS = "${

--- a/gce-production-1/service_accounts.tf
+++ b/gce-production-1/service_accounts.tf
@@ -20,6 +20,17 @@ data "terraform_remote_state" "production_2" {
   }
 }
 
+data "terraform_remote_state" "production_3" {
+  backend = "s3"
+
+  config {
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-3.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "travis-terraform-state"
+  }
+}
+
 resource "google_project_iam_member" "staging_1_workers" {
   count   = "${length(data.terraform_remote_state.staging_1.workers_service_account_emails)}"
   project = "${var.project}"
@@ -32,4 +43,11 @@ resource "google_project_iam_member" "production_2_workers" {
   project = "${var.project}"
   role    = "roles/compute.imageUser"
   member  = "serviceAccount:${element(data.terraform_remote_state.production_2.workers_service_account_emails, count.index)}"
+}
+
+resource "google_project_iam_member" "production_3_workers" {
+  count   = "${length(data.terraform_remote_state.production_3.workers_service_account_emails)}"
+  project = "${var.project}"
+  role    = "roles/compute.imageUser"
+  member  = "serviceAccount:${element(data.terraform_remote_state.production_3.workers_service_account_emails, count.index)}"
 }

--- a/gce-production-3/Makefile
+++ b/gce-production-3/Makefile
@@ -1,10 +1,7 @@
 AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
 AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
+GCE_PROJECT := travis-ci-prod-3
+GKE_CLUSTER_NAME := gce-production-3
+GKE_CLUSTER_ZONE := us-central1
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-plan:
-	@echo DISABLED OK
-
-apply:
-	@echo NO REALLY DONT DO THIS

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -3,7 +3,6 @@ variable "env" {
 }
 
 variable "gce_heroku_org" {}
-
 variable "github_users" {}
 
 variable "index" {
@@ -82,15 +81,12 @@ module "gce_worker_group" {
   syslog_address_com            = "${var.syslog_address_com}"
   syslog_address_org            = "${var.syslog_address_org}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
-  worker_subnetwork             = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
+
+  worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"
   worker_managed_instance_count_org      = "${var.worker_managed_instance_count_org}"
-
-  worker_service_accounts_count_com      = "${var.worker_managed_instance_count_com / 4}"
-  worker_service_accounts_count_com_free = "${var.worker_managed_instance_count_com_free / 4}"
-  worker_service_accounts_count_org      = "${var.worker_managed_instance_count_org / 4}"
 
   worker_config_com = <<EOF
 ### worker.env
@@ -140,6 +136,17 @@ export AWS_SECRET_ACCESS_KEY=${module.aws_iam_user_s3_org.secret}
 EOF
 }
 
+module "gke_cluster_1" {
+  source         = "../modules/gke_cluster"
+  name           = "gce-production-3"
+  gke_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
+  gke_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
+}
+
 output "workers_service_account_emails" {
   value = ["${module.gce_worker_group.workers_service_account_emails}"]
+}
+
+output "gcloud_cleanup_account_json" {
+  value = "${module.gce_worker_group.gcloud_cleanup_account_json}"
 }

--- a/gce-production-net-3/Makefile
+++ b/gce-production-net-3/Makefile
@@ -3,9 +3,3 @@ AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-plan:
-	@echo DISABLED OK
-
-apply:
-	@echo NO REALLY DONT DO THIS

--- a/gce-production-net-3/main.tf
+++ b/gce-production-net-3/main.tf
@@ -88,6 +88,14 @@ module "gce_net" {
   workers_subnet_cidr_range     = "10.10.16.0/22"
 }
 
+output "gce_network_main" {
+  value = "${module.gce_net.gce_network_main}"
+}
+
 output "gce_subnetwork_workers" {
   value = "${module.gce_net.gce_subnetwork_workers}"
+}
+
+output "gce_subnetwork_gke_cluster" {
+  value = "${module.gce_net.gce_subnetwork_gke_cluster}"
 }

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -176,6 +176,7 @@ resource "google_compute_firewall" "allow_main_ssh" {
   network       = "${google_compute_network.main.name}"
   source_ranges = ["${var.rigaer_strasse_8_ipv4}"]
   priority      = 1000
+  project       = "${var.project}"
 
   allow {
     protocol = "tcp"
@@ -273,7 +274,7 @@ resource "google_compute_address" "nat" {
 resource "aws_route53_record" "nat" {
   count   = "${length(var.nat_zones) * var.nat_count_per_zone}"
   zone_id = "${var.travisci_net_external_zone_id}"
-  name    = "${element(var.nat_names, count.index)}.gce-${var.env}-${var.region}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}.travisci.net"
+  name    = "${element(var.nat_names, count.index)}.gce-${var.env}-${var.index}-${var.region}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}.travisci.net"
   type    = "A"
   ttl     = 5
 
@@ -390,6 +391,7 @@ resource "google_compute_http_health_check" "nat" {
   check_interval_sec  = 30
   healthy_threshold   = 1
   unhealthy_threshold = 5
+  project             = "${var.project}"
 }
 
 resource "google_compute_firewall" "allow_nat_health_check" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
In the light of recent issues and awaiting the increase of our resource quotas, reviving prod-3 might be an alternative path.

## What approach did you choose and why?
Sync up the configuration with prod-1 and prod-2 so we can create an identical environment.

## How can you test this?
We can deploy it without starting workers and verify if all is there.

## What feedback would you like, if any?
This introduces new NAT IPs to the mix, requiring Maven and maybe others to update their whitelist once again. Is this the trade off we want to make?

*we must not forget to configure gcloud-cleanup on kubernetes*