### PR TITLE
Run workers on Kubernetes

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -98,6 +98,7 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
+  worker_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
   worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
@@ -158,6 +159,7 @@ module "gke_cluster_2" {
   gke_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   gke_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   k8s_default_namespace = "${var.k8s_default_namespace}"
+  k8s_max_node_count    = 50
 
   # Legacy: should become us-central1 instead.
   region = "us-central1-a"

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -98,8 +98,9 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
-  worker_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
-  worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
+  worker_docker_self_image = "travisci/worker:v6.2.0"
+  worker_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  worker_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -98,6 +98,7 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
+  worker_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
   worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
@@ -158,6 +159,7 @@ module "gke_cluster_1" {
   gke_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   gke_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   k8s_default_namespace = "${var.k8s_default_namespace}"
+  k8s_max_node_count    = 50
 }
 
 output "workers_service_account_emails" {

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -98,8 +98,9 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
-  worker_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
-  worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
+  worker_docker_self_image = "travisci/worker:v6.2.0"
+  worker_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  worker_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -98,6 +98,7 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
+  worker_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
   worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
@@ -158,6 +159,7 @@ module "gke_cluster_1" {
   gke_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   gke_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   k8s_default_namespace = "${var.k8s_default_namespace}"
+  k8s_max_node_count    = 20
 }
 
 output "workers_service_account_emails" {

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -98,8 +98,9 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
-  worker_network    = "${data.terraform_remote_state.vpc.gce_network_main}"
-  worker_subnetwork = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
+  worker_docker_self_image = "travisci/worker:v6.2.0"
+  worker_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  worker_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   worker_managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -107,7 +107,7 @@ module "gce_worker_group" {
 
   worker_managed_instance_count_com      = "${length(var.worker_zones)}"
   worker_managed_instance_count_com_free = 0
-  worker_managed_instance_count_org      = "${length(var.worker_zones)}"
+  worker_managed_instance_count_org      = 0                             #"${length(var.worker_zones)}"
 
   worker_config_com = <<EOF
 ### worker.env

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -163,6 +163,7 @@ module "gke_cluster_1" {
   gke_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   gke_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   k8s_default_namespace = "${var.k8s_default_namespace}"
+  k8s_max_node_count    = 10
 
   # Legacy: should become us-central1 instead.
   region = "us-central1-a"

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -99,7 +99,7 @@ module "gce_worker_group" {
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
-  worker_docker_self_image = "${var.latest_docker_image_worker}"
+  worker_docker_self_image = "travisci/worker:v6.2.0-80-g2472f02"
   worker_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   worker_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -105,9 +105,9 @@ module "gce_worker_group" {
 
   worker_zones = "${var.worker_zones}"
 
-  worker_managed_instance_count_com      = "${length(var.worker_zones)}"
+  worker_managed_instance_count_com      = 0
   worker_managed_instance_count_com_free = 0
-  worker_managed_instance_count_org      = 0                             #"${length(var.worker_zones)}"
+  worker_managed_instance_count_org      = 0
 
   worker_config_com = <<EOF
 ### worker.env

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -100,6 +100,7 @@ module "gce_worker_group" {
   k8s_default_namespace         = "${var.k8s_default_namespace}"
 
   worker_docker_self_image = "${var.latest_docker_image_worker}"
+  worker_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   worker_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_workers}"
 
   worker_zones = "${var.worker_zones}"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -188,6 +188,30 @@ resource "google_compute_firewall" "allow_main_ssh" {
   }
 }
 
+resource "google_compute_firewall" "allow_gke_ssh_to_jobs" {
+  name    = "allow-gke-ssh-to-jobs"
+  network = "${google_compute_network.main.name}"
+
+  source_ranges = [
+    "${google_compute_subnetwork.gke_cluster.ip_cidr_range}",
+    "${google_compute_subnetwork.gke_cluster.secondary_ip_range.0.ip_cidr_range}",
+  ]
+
+  target_tags = ["testing"]
+
+  priority = 1000
+  project  = "${var.project}"
+
+  allow {
+    protocol = "tcp"
+    ports    = [22]
+  }
+
+  lifecycle {
+    ignore_changes = ["source_ranges"]
+  }
+}
+
 resource "google_compute_firewall" "allow_public_ssh" {
   name          = "allow-public-ssh"
   network       = "${google_compute_network.main.name}"

--- a/modules/gce_net/main.tf
+++ b/modules/gce_net/main.tf
@@ -188,8 +188,8 @@ resource "google_compute_firewall" "allow_main_ssh" {
   }
 }
 
-resource "google_compute_firewall" "allow_gke_ssh_to_jobs" {
-  name    = "allow-gke-ssh-to-jobs"
+resource "google_compute_firewall" "allow_gke_worker_to_jobs" {
+  name    = "allow-gke-workers-to-jobs"
   network = "${google_compute_network.main.name}"
 
   source_ranges = [
@@ -202,9 +202,10 @@ resource "google_compute_firewall" "allow_gke_ssh_to_jobs" {
   priority = 1000
   project  = "${var.project}"
 
+  # 5986/wsman for Windows machines
   allow {
     protocol = "tcp"
-    ports    = [22]
+    ports    = [22, 5986]
   }
 
   lifecycle {

--- a/modules/gce_worker/accounts-com-free.tf
+++ b/modules/gce_worker/accounts-com-free.tf
@@ -11,3 +11,15 @@ resource "google_project_iam_member" "workers_com_free" {
 resource "google_service_account_key" "workers_com_free" {
   service_account_id = "${google_service_account.workers_com_free.email}"
 }
+
+resource "kubernetes_secret" "worker_com_free_config" {
+  metadata {
+    name      = "worker-com-free-terraform"
+    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+  }
+
+  data = {
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.worker_com_free.private_key)}"
+    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
+  }
+}

--- a/modules/gce_worker/accounts-com-free.tf
+++ b/modules/gce_worker/accounts-com-free.tf
@@ -1,0 +1,13 @@
+resource "google_service_account" "workers_com_free" {
+  account_id   = "workers-com-free-${lookup(var.regions_abbrev, var.region, "unk")}"
+  display_name = "travis-worker processes com free ${var.region}"
+}
+
+resource "google_project_iam_member" "workers_com_free" {
+  role   = "projects/${var.project}/roles/${google_project_iam_custom_role.worker.role_id}"
+  member = "serviceAccount:${google_service_account.workers_com_free.email}"
+}
+
+resource "google_service_account_key" "workers_com_free" {
+  service_account_id = "${google_service_account.workers_com_free.email}"
+}

--- a/modules/gce_worker/accounts-com-free.tf
+++ b/modules/gce_worker/accounts-com-free.tf
@@ -11,15 +11,3 @@ resource "google_project_iam_member" "workers_com_free" {
 resource "google_service_account_key" "workers_com_free" {
   service_account_id = "${google_service_account.workers_com_free.email}"
 }
-
-resource "kubernetes_secret" "worker_com_free_config" {
-  metadata {
-    name      = "worker-com-free-terraform"
-    namespace = "${var.k8s_namespace}"
-  }
-
-  data = {
-    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
-    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
-  }
-}

--- a/modules/gce_worker/accounts-com-free.tf
+++ b/modules/gce_worker/accounts-com-free.tf
@@ -15,11 +15,11 @@ resource "google_service_account_key" "workers_com_free" {
 resource "kubernetes_secret" "worker_com_free_config" {
   metadata {
     name      = "worker-com-free-terraform"
-    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+    namespace = "${var.k8s_namespace}"
   }
 
   data = {
-    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.worker_com_free.private_key)}"
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
   }
 }

--- a/modules/gce_worker/accounts-com.tf
+++ b/modules/gce_worker/accounts-com.tf
@@ -15,11 +15,11 @@ resource "google_service_account_key" "workers_com" {
 resource "kubernetes_secret" "worker_com_config" {
   metadata {
     name      = "worker-com-terraform"
-    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+    namespace = "${var.k8s_namespace}"
   }
 
   data = {
-    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.worker_com.private_key)}"
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com.private_key)}"
   }
 }

--- a/modules/gce_worker/accounts-com.tf
+++ b/modules/gce_worker/accounts-com.tf
@@ -1,0 +1,13 @@
+resource "google_service_account" "workers_com" {
+  account_id   = "workers-com-${lookup(var.regions_abbrev, var.region, "unk")}"
+  display_name = "travis-worker processes com ${var.region}"
+}
+
+resource "google_project_iam_member" "workers_com" {
+  role   = "projects/${var.project}/roles/${google_project_iam_custom_role.worker.role_id}"
+  member = "serviceAccount:${google_service_account.workers_com.email}"
+}
+
+resource "google_service_account_key" "workers_com" {
+  service_account_id = "${google_service_account.workers_com.email}"
+}

--- a/modules/gce_worker/accounts-com.tf
+++ b/modules/gce_worker/accounts-com.tf
@@ -11,3 +11,15 @@ resource "google_project_iam_member" "workers_com" {
 resource "google_service_account_key" "workers_com" {
   service_account_id = "${google_service_account.workers_com.email}"
 }
+
+resource "kubernetes_secret" "worker_com_config" {
+  metadata {
+    name      = "worker-com-terraform"
+    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+  }
+
+  data = {
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.worker_com.private_key)}"
+    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com.private_key)}"
+  }
+}

--- a/modules/gce_worker/accounts-com.tf
+++ b/modules/gce_worker/accounts-com.tf
@@ -11,15 +11,3 @@ resource "google_project_iam_member" "workers_com" {
 resource "google_service_account_key" "workers_com" {
   service_account_id = "${google_service_account.workers_com.email}"
 }
-
-resource "kubernetes_secret" "worker_com_config" {
-  metadata {
-    name      = "worker-com-terraform"
-    namespace = "${var.k8s_namespace}"
-  }
-
-  data = {
-    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com.private_key)}"
-    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com.private_key)}"
-  }
-}

--- a/modules/gce_worker/accounts-org.tf
+++ b/modules/gce_worker/accounts-org.tf
@@ -11,3 +11,15 @@ resource "google_project_iam_member" "workers_org" {
 resource "google_service_account_key" "workers_org" {
   service_account_id = "${google_service_account.workers_org.email}"
 }
+
+resource "kubernetes_secret" "worker_org_config" {
+  metadata {
+    name      = "worker-org-terraform"
+    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+  }
+
+  data = {
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.worker_org.private_key)}"
+    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_org.private_key)}"
+  }
+}

--- a/modules/gce_worker/accounts-org.tf
+++ b/modules/gce_worker/accounts-org.tf
@@ -1,0 +1,13 @@
+resource "google_service_account" "workers_org" {
+  account_id   = "workers-org-${lookup(var.regions_abbrev, var.region, "unk")}"
+  display_name = "travis-worker processes org ${var.region}"
+}
+
+resource "google_project_iam_member" "workers_org" {
+  role   = "projects/${var.project}/roles/${google_project_iam_custom_role.worker.role_id}"
+  member = "serviceAccount:${google_service_account.workers_org.email}"
+}
+
+resource "google_service_account_key" "workers_org" {
+  service_account_id = "${google_service_account.workers_org.email}"
+}

--- a/modules/gce_worker/accounts-org.tf
+++ b/modules/gce_worker/accounts-org.tf
@@ -15,11 +15,11 @@ resource "google_service_account_key" "workers_org" {
 resource "kubernetes_secret" "worker_org_config" {
   metadata {
     name      = "worker-org-terraform"
-    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+    namespace = "${var.k8s_namespace}"
   }
 
   data = {
-    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.worker_org.private_key)}"
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_org.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_org.private_key)}"
   }
 }

--- a/modules/gce_worker/accounts-org.tf
+++ b/modules/gce_worker/accounts-org.tf
@@ -11,15 +11,3 @@ resource "google_project_iam_member" "workers_org" {
 resource "google_service_account_key" "workers_org" {
   service_account_id = "${google_service_account.workers_org.email}"
 }
-
-resource "kubernetes_secret" "worker_org_config" {
-  metadata {
-    name      = "worker-org-terraform"
-    namespace = "${var.k8s_namespace}"
-  }
-
-  data = {
-    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_org.private_key)}"
-    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_org.private_key)}"
-  }
-}

--- a/modules/gce_worker/kubernetes-com-free.tf
+++ b/modules/gce_worker/kubernetes-com-free.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_secret" "worker_com_free_config" {
+  metadata {
+    name      = "worker-com-free-terraform"
+    namespace = "${var.k8s_namespace}"
+  }
+
+  data = {
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
+    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
+  }
+}

--- a/modules/gce_worker/kubernetes-com-free.tf
+++ b/modules/gce_worker/kubernetes-com-free.tf
@@ -7,7 +7,7 @@ resource "kubernetes_secret" "worker_com_free_config" {
   data = {
     TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
-    TRAVIS_WORKER_GCE_NETWORK                    = "${var.network_workers}"
-    TRAVIS_WORKER_GCE_SUBNETWORK                 = "${var.subnetwork_workers}"
+    TRAVIS_WORKER_GCE_NETWORK                    = "main"
+    TRAVIS_WORKER_GCE_SUBNETWORK                 = "jobs-com"
   }
 }

--- a/modules/gce_worker/kubernetes-com-free.tf
+++ b/modules/gce_worker/kubernetes-com-free.tf
@@ -7,5 +7,7 @@ resource "kubernetes_secret" "worker_com_free_config" {
   data = {
     TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com_free.private_key)}"
+    TRAVIS_WORKER_GCE_NETWORK                    = "${var.network_workers}"
+    TRAVIS_WORKER_GCE_SUBNETWORK                 = "${var.subnetwork_workers}"
   }
 }

--- a/modules/gce_worker/kubernetes-com.tf
+++ b/modules/gce_worker/kubernetes-com.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_secret" "worker_com_config" {
+  metadata {
+    name      = "worker-com-terraform"
+    namespace = "${var.k8s_namespace}"
+  }
+
+  data = {
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com.private_key)}"
+    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com.private_key)}"
+  }
+}

--- a/modules/gce_worker/kubernetes-com.tf
+++ b/modules/gce_worker/kubernetes-com.tf
@@ -7,7 +7,7 @@ resource "kubernetes_secret" "worker_com_config" {
   data = {
     TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com.private_key)}"
-    TRAVIS_WORKER_GCE_NETWORK                    = "${var.network_workers}"
-    TRAVIS_WORKER_GCE_SUBNETWORK                 = "${var.subnetwork_workers}"
+    TRAVIS_WORKER_GCE_NETWORK                    = "main"
+    TRAVIS_WORKER_GCE_SUBNETWORK                 = "jobs-com"
   }
 }

--- a/modules/gce_worker/kubernetes-com.tf
+++ b/modules/gce_worker/kubernetes-com.tf
@@ -7,5 +7,7 @@ resource "kubernetes_secret" "worker_com_config" {
   data = {
     TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_com.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_com.private_key)}"
+    TRAVIS_WORKER_GCE_NETWORK                    = "${var.network_workers}"
+    TRAVIS_WORKER_GCE_SUBNETWORK                 = "${var.subnetwork_workers}"
   }
 }

--- a/modules/gce_worker/kubernetes-org.tf
+++ b/modules/gce_worker/kubernetes-org.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_secret" "worker_org_config" {
+  metadata {
+    name      = "worker-org-terraform"
+    namespace = "${var.k8s_namespace}"
+  }
+
+  data = {
+    TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_org.private_key)}"
+    TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_org.private_key)}"
+  }
+}

--- a/modules/gce_worker/kubernetes-org.tf
+++ b/modules/gce_worker/kubernetes-org.tf
@@ -7,5 +7,7 @@ resource "kubernetes_secret" "worker_org_config" {
   data = {
     TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_org.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_org.private_key)}"
+    TRAVIS_WORKER_GCE_NETWORK                    = "${var.network_workers}"
+    TRAVIS_WORKER_GCE_SUBNETWORK                 = "${var.subnetwork_workers}"
   }
 }

--- a/modules/gce_worker/kubernetes-org.tf
+++ b/modules/gce_worker/kubernetes-org.tf
@@ -7,7 +7,7 @@ resource "kubernetes_secret" "worker_org_config" {
   data = {
     TRAVIS_WORKER_GCE_ACCOUNT_JSON               = "${base64decode(google_service_account_key.workers_org.private_key)}"
     TRAVIS_WORKER_STACKDRIVER_TRACE_ACCOUNT_JSON = "${base64decode(google_service_account_key.workers_org.private_key)}"
-    TRAVIS_WORKER_GCE_NETWORK                    = "${var.network_workers}"
-    TRAVIS_WORKER_GCE_SUBNETWORK                 = "${var.subnetwork_workers}"
+    TRAVIS_WORKER_GCE_NETWORK                    = "main"
+    TRAVIS_WORKER_GCE_SUBNETWORK                 = "jobs-org"
   }
 }

--- a/modules/gce_worker/role-worker.tf
+++ b/modules/gce_worker/role-worker.tf
@@ -1,18 +1,3 @@
-resource "google_service_account" "workers_com" {
-  account_id   = "workers-com-${lookup(var.regions_abbrev, var.region, "unk")}"
-  display_name = "travis-worker processes com ${var.region}"
-}
-
-resource "google_service_account" "workers_com_free" {
-  account_id   = "workers-com-free-${lookup(var.regions_abbrev, var.region, "unk")}"
-  display_name = "travis-worker processes com free ${var.region}"
-}
-
-resource "google_service_account" "workers_org" {
-  account_id   = "workers-org-${lookup(var.regions_abbrev, var.region, "unk")}"
-  display_name = "travis-worker processes org ${var.region}"
-}
-
 resource "google_project_iam_custom_role" "worker" {
   role_id     = "worker"
   title       = "travis-worker"
@@ -105,31 +90,4 @@ resource "google_project_iam_custom_role" "worker" {
     "compute.zones.get",
     "compute.zones.list",
   ]
-}
-
-resource "google_project_iam_member" "workers_com" {
-  role   = "projects/${var.project}/roles/${google_project_iam_custom_role.worker.role_id}"
-  member = "serviceAccount:${google_service_account.workers_com.email}"
-}
-
-resource "google_service_account_key" "workers_com" {
-  service_account_id = "${google_service_account.workers_com.email}"
-}
-
-resource "google_project_iam_member" "workers_com_free" {
-  role   = "projects/${var.project}/roles/${google_project_iam_custom_role.worker.role_id}"
-  member = "serviceAccount:${google_service_account.workers_com_free.email}"
-}
-
-resource "google_service_account_key" "workers_com_free" {
-  service_account_id = "${google_service_account.workers_com_free.email}"
-}
-
-resource "google_project_iam_member" "workers_org" {
-  role   = "projects/${var.project}/roles/${google_project_iam_custom_role.worker.role_id}"
-  member = "serviceAccount:${google_service_account.workers_org.email}"
-}
-
-resource "google_service_account_key" "workers_org" {
-  service_account_id = "${google_service_account.workers_org.email}"
 }

--- a/modules/gce_worker/variables.tf
+++ b/modules/gce_worker/variables.tf
@@ -1,6 +1,7 @@
 variable "config_com" {}
 variable "config_com_free" {}
 variable "config_org" {}
+variable "k8s_namespace" {}
 variable "env" {}
 variable "github_users" {}
 variable "index" {}

--- a/modules/gce_worker/variables.tf
+++ b/modules/gce_worker/variables.tf
@@ -23,6 +23,7 @@ variable "regions_abbrev" {
   }
 }
 
+variable "network_workers" {}
 variable "subnetwork_workers" {}
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}

--- a/modules/gce_worker_group/variables.tf
+++ b/modules/gce_worker_group/variables.tf
@@ -43,6 +43,7 @@ variable "worker_machine_type" {
   default = "g1-small"
 }
 
+variable "worker_network" {}
 variable "worker_subnetwork" {}
 
 variable "worker_zones" {

--- a/modules/gce_worker_group/workers.tf
+++ b/modules/gce_worker_group/workers.tf
@@ -17,6 +17,7 @@ module "gce_workers" {
   machine_type             = "${var.worker_machine_type}"
   project                  = "${var.project}"
   region                   = "${var.region}"
+  network_workers          = "${var.worker_network}"
   subnetwork_workers       = "${var.worker_subnetwork}"
   syslog_address_com       = "${var.syslog_address_com}"
   syslog_address_org       = "${var.syslog_address_org}"

--- a/modules/gce_worker_group/workers.tf
+++ b/modules/gce_worker_group/workers.tf
@@ -5,9 +5,10 @@ module "gce_workers" {
   config_com_free = "${var.worker_config_com_free}"
   config_org      = "${var.worker_config_org}"
 
-  env          = "${var.env}"
-  github_users = "${var.github_users}"
-  index        = "${var.index}"
+  k8s_namespace = "${kubernetes_namespace.default.metadata.0.name}"
+  env           = "${var.env}"
+  github_users  = "${var.github_users}"
+  index         = "${var.index}"
 
   managed_instance_count_com      = "${var.worker_managed_instance_count_com}"
   managed_instance_count_com_free = "${var.worker_managed_instance_count_com_free}"

--- a/modules/gke_cluster/gke.tf
+++ b/modules/gke_cluster/gke.tf
@@ -16,6 +16,14 @@ variable "gke_subnetwork" {
 
 variable "k8s_default_namespace" {}
 
+variable "k8s_max_node_count" {
+  default = 3
+}
+
+variable "k8s_machine_type" {
+  default = "n1-standard-1"
+}
+
 resource "google_container_cluster" "gke_cluster" {
   name                     = "${var.name}"
   location                 = "${var.region}"
@@ -44,6 +52,8 @@ resource "google_container_node_pool" "node_pool" {
   cluster            = "${google_container_cluster.gke_cluster.name}"
 
   node_config {
+    machine_type = "${var.k8s_machine_type}"
+
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
@@ -59,7 +69,7 @@ resource "google_container_node_pool" "node_pool" {
 
   autoscaling {
     min_node_count = 1
-    max_node_count = 3
+    max_node_count = "${var.k8s_max_node_count}"
   }
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
We want to run the workers on Kubernetes, this allows us to scale the workers more dynamically and have easier debugging access to workers (k8s tooling vs. ssh).

## What approach did you choose and why?
Matt already build a Kubernetes cluster on Macstadium with a [worker-operator](https://github.com/travis-ci/worker-operator) and Emma started work on a [gce-worker Helm chart](https://github.com/travis-ci/kubernetes-config/pull/47) already. Essentially, I'm pulling these together.

As I use Terraform to set the 'account json' to access the GCE API, I ran into a little bug, please see more at https://github.com/travis-ci/worker/pull/601. I guess fixing this will also result in a new version of `worker`.

Todo:
- [x] Run a Redis on k8s to follow up on the GCP API rate limits.
- [x] Release new worker (v6.2.1)

## How can you test this?
I'm running Kubernetes workers for .org on staging. It picks up [my build](https://staging.travis-ci.org/Duologic/twitter-test-stream/builds/743240) and follows up on it.

## What feedback would you like, if any?
If you have any.

Related PRs:
- https://github.com/travis-ci/kubernetes-config/pull/47
- https://github.com/travis-ci/worker/pull/601