### PR TITLE
Revert Cloud NAT change

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,6 +35,7 @@ Metrics/MethodLength:
 # Blacklist: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))
 Naming/HeredocDelimiterNaming:
   Exclude:
+    - 'bin/gcloud-nats-by-zone'
     - 'bin/generate-latest-gce-images'
     - 'bin/write-config-files'
 

--- a/assets/nat/var/tmp/nat-conntracker-confs/fail2ban-action-iptables-blocktype.local
+++ b/assets/nat/var/tmp/nat-conntracker-confs/fail2ban-action-iptables-blocktype.local
@@ -1,0 +1,2 @@
+[Init]
+blocktype = DROP

--- a/assets/nat/var/tmp/nat-conntracker-confs/fail2ban-filter-nat-conntracker.conf
+++ b/assets/nat/var/tmp/nat-conntracker-confs/fail2ban-filter-nat-conntracker.conf
@@ -1,0 +1,6 @@
+[Definition]
+failregex = ^.*time=\S+ level=WARNING over threshold=\d+ src=<HOST> dst=\S+ count=\d+.*$
+ignoreregex =
+
+[Init]
+journalmatch = _SYSTEMD_UNIT=nat-conntracker.service

--- a/assets/nat/var/tmp/nat-conntracker-confs/fail2ban-jail-nat-conntracker.conf
+++ b/assets/nat/var/tmp/nat-conntracker-confs/fail2ban-jail-nat-conntracker.conf
@@ -1,0 +1,9 @@
+[nat-conntracker]
+backend = systemd
+banaction = iptables-allports
+bantime = 30
+chain = FORWARD
+enabled = true
+ignoreip = 127.0.0.1/8 10.10.0.0/16
+maxretry = 1
+protocol = all

--- a/assets/nat/var/tmp/nat-conntracker-confs/fail2ban.local
+++ b/assets/nat/var/tmp/nat-conntracker-confs/fail2ban.local
@@ -1,0 +1,2 @@
+[Definition]
+logtarget = SYSLOG

--- a/assets/nat/var/tmp/nftables.conf
+++ b/assets/nat/var/tmp/nftables.conf
@@ -1,0 +1,10 @@
+table ip nat {
+        chain prerouting {
+                type nat hook prerouting priority 0; policy accept;
+        }
+
+        chain postrouting {
+                type nat hook postrouting priority 100; policy accept;
+                masquerade
+        }
+}

--- a/bin/gce-export-net
+++ b/bin/gce-export-net
@@ -31,9 +31,12 @@ def main
   command = %W[#{terraform} state rm] + (
     %w[
       aws_route53_record.bastion-b
+      aws_route53_record.nat-b
       google_compute_address.bastion-b
       google_compute_address.bastion[0]
+      google_compute_address.nat-b
       google_compute_firewall.allow_internal
+      google_compute_firewall.allow_jobs_nat
       google_compute_firewall.allow_public_icmp
       google_compute_firewall.allow_public_ssh
       google_compute_firewall.deny_target_ip

--- a/bin/gce-import-net
+++ b/bin/gce-import-net
@@ -49,6 +49,7 @@ def main
   {
     'google_compute_address.bastion[0]' => 'bastion-b',
     'google_compute_firewall.allow_internal' => 'allow-internal',
+    'google_compute_firewall.allow_jobs_nat' => 'allow-jobs-nat',
     'google_compute_firewall.allow_public_icmp' => 'allow-public-icmp',
     'google_compute_firewall.allow_public_ssh' => 'allow-public-ssh',
     'google_compute_firewall.deny_target_ip' => 'deny-target-ip',

--- a/bin/gcloud-nats-by-zone
+++ b/bin/gcloud-nats-by-zone
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+NOTSET = '<notset>'
+
+def main(argv: ARGV)
+  return usage if $stdin.tty? || argv.include?('-h') || argv.include?('--help')
+
+  in_args = JSON.parse($stdin.read)
+  zones = in_args.fetch('zones', '').split(',').map(&:strip).reject(&:empty?)
+  count = Integer(in_args.fetch('count', zones.length))
+  project = in_args.fetch('project')
+  region = in_args.fetch('region')
+  retries = Integer(in_args.fetch('retries', '4'))
+  retry_sleep = Integer(in_args.fetch('retry_sleep', '120'))
+  accounting = %w[1 yes on true].include?(
+    ENV.fetch(
+      'ACCOUNTING', in_args.fetch('accounting', true)
+    ).to_s
+  )
+  retried = 0
+
+  instances = {}
+  while retried <= retries
+    instances = fetch_nats_by_zone(zones, count, project, region)
+    break unless accounting
+    break if instances.length == count
+
+    warn(
+      "#{$PROGRAM_NAME}: sleeping=#{retry_sleep}s " \
+      "instances_length=#{instances.length} count=#{count}"
+    )
+
+    sleep(retry_sleep)
+    retried += 1
+  end
+
+  $stdout.puts(JSON.pretty_generate(instances))
+  0
+end
+
+def fetch_nats_by_zone(zones, count, project, region)
+  instances = {}
+  instances_command = %w[
+    gcloud compute instance-groups list-instances
+  ]
+
+  zones.each do |zone|
+    (count / zones.length).times do |count_index|
+      full_command = instances_command + %W[
+        nat-#{zone}-#{count_index + 1}
+        --project=#{project}
+        --zone=#{region}-#{zone}
+        --format="value(instance)"
+      ]
+      instance_name = `#{full_command.join(' ')}`.strip
+      next if instance_name.empty?
+
+      instances["nat-#{zone}-#{count_index + 1}"] = %W[
+        projects
+        #{project}
+        zones
+        #{region}-#{zone}
+        instances
+        #{instance_name}
+      ].join('/')
+    rescue StandardError => e
+      warn e
+    end
+  end
+
+  instances
+end
+
+def usage
+  warn <<~EOF
+    Usage: #{$PROGRAM_NAME} [-h|--help]
+
+    Print a mapping of {zone}-{index}=>{instance-id} given a JSON blob
+    containing the following arguments provided via stdin:
+
+    accounting - boolean controlling count check and retries, default=false
+    count - total number of expected instances, default=zones.length
+    project - the gcloud project name *REQUIRED*
+    region - the region in which to look for nat instances *REQUIRED*
+    retries - number of total retries, default=4
+    retry_sleep - sleep interval between retries, default=120
+    zones - a comma-delimited list of zones within the region
+  EOF
+  2
+end
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/bin/gcloud-recreate-nat-instances
+++ b/bin/gcloud-recreate-nat-instances
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require 'json'
+
+def main
+  options = { env: '', noop: false }
+  OptionParser.new do |opts|
+    opts.banner = <<~BANNER
+      Usage: gcloud-recreate-nat-instances [options]
+
+      Recreates the NAT instances managed by the instance groups specified using
+      the GCE_NAT_GROUPS environment variable.  Also requires GCE_NAT_PROJECT
+      and GCE_NAT_REGION to be set.
+
+    BANNER
+
+    opts.on('-E', '--env=ENV_FILE') do |f|
+      options[:env] = f.strip
+    end
+
+    opts.on('-n', '--noop') do
+      options[:noop] = true
+    end
+
+    opts.on('--help') do
+      puts opts
+      exit
+    end
+  end.parse!
+
+  env = Hash[ENV]
+  env.merge!(source_env(options[:env])) unless options[:env].empty?
+
+  project = env.fetch('GCE_NAT_PROJECT')
+  region = env.fetch('GCE_NAT_REGION')
+  groups = env.fetch('GCE_NAT_GROUPS').split(',').map(&:strip)
+
+  groups_zones = groups.map do |group|
+    [group, "#{region}-#{group.split('-').fetch(1)}"]
+  end
+  groups_zones = Hash[groups_zones]
+
+  groups_zones.each do |instance_group, zone|
+    instance_list = list_instances(instance_group, zone, project)
+    instances = instance_list.map { |r| r.fetch('instance').split('/').last }
+    command = %W[
+      gcloud compute instance-groups managed recreate-instances
+      #{instance_group} --zone=#{zone} --project=#{project}
+      --instances=#{instances.join(',')}
+    ]
+    run_command(command, options.fetch(:noop))
+  end
+
+  0
+end
+
+def list_instances(instance_group, zone, project)
+  command = %W[
+    gcloud compute instance-groups list-instances
+    #{instance_group}
+    --zone=#{zone}
+    --project=#{project}
+    --format=json
+  ]
+  JSON.parse(`#{command.join(' ')}`)
+end
+
+def run_command(command, noop)
+  if noop
+    puts "---> NOOP: #{command.join(' ').inspect}"
+  else
+    puts "---> RUNNING: #{command.join(' ').inspect}"
+    system(*command)
+  end
+end
+
+def source_env(env_file)
+  base_env = `bash -c 'printenv'`.split($RS).map do |l|
+    l.strip.split('=', 2)
+  end
+  base_env = Hash[base_env]
+  sourced_env = `bash -c "source #{env_file}; printenv"`.split($RS).map do |l|
+    l.strip.split('=', 2)
+  end
+  sourced_env = Hash[sourced_env]
+  base_env.keys.each { |k| sourced_env.delete(k) }
+  sourced_env
+end
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/bin/generate-latest-docker-image-tags
+++ b/bin/generate-latest-docker-image-tags
@@ -32,7 +32,6 @@ def main
   end
 
   %w[
-    gesund
     worker
   ].each do |image|
     tag = latest_docker_image_tag("travisci/#{image}")

--- a/bin/generate-latest-docker-image-tags
+++ b/bin/generate-latest-docker-image-tags
@@ -32,6 +32,8 @@ def main
   end
 
   %w[
+    gesund
+    nat-conntracker
     worker
   ].each do |image|
     tag = latest_docker_image_tag("travisci/#{image}")

--- a/bin/nat-conntracker-configure
+++ b/bin/nat-conntracker-configure
@@ -1,0 +1,88 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'net/https'
+require 'optparse'
+
+def main
+  options = {
+    app: '',
+    dst_ignore: [],
+    heroku_api_hostname: 'api.heroku.com',
+    heroku_api_key: ENV.fetch('HEROKU_API_KEY', ''),
+    src_ignore: []
+  }
+
+  OptionParser.new do |opts|
+    opts.on(
+      '-a', '--app=APP',
+      'name of nat-conntracker heroku app'
+    ) { |v| options[:app] = v.strip }
+
+    opts.on(
+      '-d', '--dst-ignore=CIDRS',
+      'comma-delimited list of destination CIDRs to ignore'
+    ) { |v| options[:dst_ignore] = v.split(',').map(&:strip) }
+
+    opts.on(
+      '-s', '--src-ignore=CIDRS',
+      'comma-delimited list of source CIDRs to ignore'
+    ) { |v| options[:src_ignore] = v.split(',').map(&:strip) }
+
+    opts.on(
+      '--heroku-api-hostname=HOSTNAME',
+      'hostname of Heroku API from which to fetch stuff'
+    ) { |v| options[:heroku_api_hostname] = v.strip }
+
+    opts.on(
+      '--heroku-api-key=KEY',
+      'API key to use with Heroku API'
+    ) { |v| options[:heroku_api_key] = v.strip }
+  end.parse!
+
+  expand_private!(options[:dst_ignore])
+  expand_private!(options[:src_ignore])
+
+  unless Array(options[:dst_ignore]).empty?
+    dst_command = %W[
+      trvs redis-cli #{options[:app]} REDIS_URL SADD nat-conntracker:dst-ignore
+    ] + Array(options[:dst_ignore])
+    warn("---> #{dst_command.join(' ')}")
+    system(*dst_command)
+  end
+
+  unless Array(options[:src_ignore]).empty?
+    src_command = %W[
+      trvs redis-cli #{options[:app]} REDIS_URL SADD nat-conntracker:src-ignore
+    ] + Array(options[:src_ignore])
+    warn("---> #{src_command.join(' ')}")
+    system(*src_command)
+  end
+
+  0
+end
+
+def expand_private!(cidrs)
+  cidrs.map! do |cidr|
+    if cidr == 'private'
+      PRIVATE_SUBNETS
+    else
+      cidr
+    end
+  end
+  cidrs.flatten!
+  cidrs
+end
+
+PRIVATE_SUBNETS = %w[
+  10.0.0.0/8
+  127.0.0.0/8
+  169.254.0.0/16
+  172.16.0.0/12
+  192.0.2.0/24
+  192.168.0.0/16
+].freeze
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/bin/write-config-files
+++ b/bin/write-config-files
@@ -36,6 +36,16 @@ def main(argv: ARGV)
     )
   end
 
+  if opts[:write_nat]
+    fwrite(
+      'config/nat.env',
+      trvs_gen(
+        "#{opts[:infra]}-nat", opts[:env_short],
+        pro: true, prefix: "#{opts[:infra].upcase}_NAT"
+      )
+    )
+  end
+
   {
     'config/travis-org.env' => "travis-#{opts[:env_short]}",
     'config/travis-build-org.env' => "travis-build-#{opts[:env_short]}",
@@ -104,7 +114,8 @@ def parse_argv(argv)
     job_board_host: '',
     amqp_url_com_varname: '',
     amqp_url_org_varname: '',
-    write_bastion: false
+    write_bastion: false,
+    write_nat: false
   }
 
   OptionParser.new do |o|
@@ -142,6 +153,10 @@ def parse_argv(argv)
 
     o.on('--write-bastion') do
       opts[:write_bastion] = true
+    end
+
+    o.on('--write-nat') do
+      opts[:write_nat] = true
     end
   end.parse(argv)
 

--- a/gce-production-1/Makefile
+++ b/gce-production-1/Makefile
@@ -1,4 +1,4 @@
-include $(shell git rev-parse --show-toplevel)/gce.mk
+AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
+AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 
-.PHONY: .config
-.config: $(ENV_NAME).auto.tfvars
+include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-2/Makefile
+++ b/gce-production-2/Makefile
@@ -1,4 +1,4 @@
-include $(shell git rev-parse --show-toplevel)/gce.mk
+AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
+AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 
-.PHONY: .config
-.config: $(ENV_NAME).auto.tfvars
+include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-3/Makefile
+++ b/gce-production-3/Makefile
@@ -1,4 +1,4 @@
-include $(shell git rev-parse --show-toplevel)/gce.mk
+AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
+AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 
-.PHONY: .config
-.config: $(ENV_NAME).auto.tfvars
+include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-net-1/Makefile
+++ b/gce-production-net-1/Makefile
@@ -3,19 +3,3 @@ AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-WRITE_CONFIG_OPTS := --write-bastion --env-tail $(ENV_TAIL)
-
-.PHONY: default
-default: hello
-
-CONFIG_FILES := \
-	config/bastion.env \
-	config/gce-workers-$(ENV_SHORT).json \
-	config/worker-com.env \
-	config/worker-org.env
-
-.PHONY: .config
-.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
-
-$(CONFIG_FILES): config/.written config/.gce-keys-written

--- a/gce-production-net-1/main.tf
+++ b/gce-production-net-1/main.tf
@@ -10,10 +10,24 @@ variable "gce_bastion_image" {
   default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1519767738-74530dd"
 }
 
+variable "gce_heroku_org" {}
+
+variable "gce_nat_image" {
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
+}
+
 variable "github_users" {}
 
 variable "index" {
   default = 1
+}
+
+variable "nat_conntracker_src_ignore" {
+  type = "list"
+}
+
+variable "nat_conntracker_dst_ignore" {
+  type = "list"
 }
 
 variable "project" {
@@ -53,13 +67,21 @@ provider "heroku" {}
 module "gce_net" {
   source = "../modules/gce_net"
 
-  bastion_config                = "${file("config/bastion.env")}"
-  bastion_image                 = "${var.gce_bastion_image}"
-  deny_target_ip_ranges         = ["${var.deny_target_ip_ranges}"]
-  env                           = "${var.env}"
+  bastion_config        = "${file("config/bastion.env")}"
+  bastion_image         = "${var.gce_bastion_image}"
+  deny_target_ip_ranges = ["${var.deny_target_ip_ranges}"]
+  env                   = "${var.env}"
+
   github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
+  nat_config                    = "${file("config/nat.env")}"
+  nat_conntracker_config        = "${file("nat-conntracker.env")}"
+  nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
+  nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
   nat_count_per_zone            = 2
+  nat_image                     = "${var.gce_nat_image}"
+  nat_machine_type              = "n1-standard-4"
   project                       = "${var.project}"
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"
   syslog_address                = "${var.syslog_address_com}"

--- a/gce-production-net-1/main.tf
+++ b/gce-production-net-1/main.tf
@@ -86,19 +86,6 @@ module "gce_net" {
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"
   syslog_address                = "${var.syslog_address_com}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
-
-  # Legacy: nat_name order of prod-1 is different, see commit f279f65597
-  # Removing this would create new NAT IP addresses and should be done with care.
-  nat_names = [
-    "nat-a-1",
-    "nat-a-2",
-    "nat-b-1",
-    "nat-b-2",
-    "nat-c-1",
-    "nat-c-2",
-    "nat-f-1",
-    "nat-f-2",
-  ]
 }
 
 data "google_compute_network" "main" {

--- a/gce-production-net-1/nat-conntracker.env
+++ b/gce-production-net-1/nat-conntracker.env
@@ -1,0 +1,4 @@
+export NAT_CONNTRACKER_CONNTRACK_ARGS=-E+conntrack+--output+xml+--event-mask+NEW+--buffer-size+25000000
+export NAT_CONNTRACKER_CONN_THRESHOLD=100
+export NAT_CONNTRACKER_GIT_REF=master
+export NAT_CONNTRACKER_TOP_N=100

--- a/gce-production-net-2/Makefile
+++ b/gce-production-net-2/Makefile
@@ -3,19 +3,3 @@ AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-WRITE_CONFIG_OPTS := --write-bastion --env-tail $(ENV_TAIL)
-
-.PHONY: default
-default: hello
-
-CONFIG_FILES := \
-	config/bastion.env \
-	config/gce-workers-$(ENV_SHORT).json \
-	config/worker-com.env \
-	config/worker-org.env
-
-.PHONY: .config
-.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
-
-$(CONFIG_FILES): config/.written config/.gce-keys-written

--- a/gce-production-net-2/main.tf
+++ b/gce-production-net-2/main.tf
@@ -10,10 +10,24 @@ variable "gce_bastion_image" {
   default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1519767738-74530dd"
 }
 
+variable "gce_heroku_org" {}
+
+variable "gce_nat_image" {
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
+}
+
 variable "github_users" {}
 
 variable "index" {
   default = 2
+}
+
+variable "nat_conntracker_src_ignore" {
+  type = "list"
+}
+
+variable "nat_conntracker_dst_ignore" {
+  type = "list"
 }
 
 variable "project" {
@@ -53,13 +67,21 @@ provider "heroku" {}
 module "gce_net" {
   source = "../modules/gce_net"
 
-  bastion_config                = "${file("config/bastion.env")}"
-  bastion_image                 = "${var.gce_bastion_image}"
-  deny_target_ip_ranges         = ["${var.deny_target_ip_ranges}"]
-  env                           = "${var.env}"
+  bastion_config        = "${file("config/bastion.env")}"
+  bastion_image         = "${var.gce_bastion_image}"
+  deny_target_ip_ranges = ["${var.deny_target_ip_ranges}"]
+  env                   = "${var.env}"
+
   github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
+  nat_config                    = "${file("config/nat.env")}"
+  nat_conntracker_config        = "${file("nat-conntracker.env")}"
+  nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
+  nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
   nat_count_per_zone            = 2
+  nat_image                     = "${var.gce_nat_image}"
+  nat_machine_type              = "n1-standard-4"
   project                       = "${var.project}"
   public_subnet_cidr_range      = "10.10.1.0/24"
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"

--- a/gce-production-net-2/nat-conntracker.env
+++ b/gce-production-net-2/nat-conntracker.env
@@ -1,0 +1,4 @@
+export NAT_CONNTRACKER_CONNTRACK_ARGS=-E+conntrack+--output+xml+--event-mask+NEW+--buffer-size+25000000
+export NAT_CONNTRACKER_CONN_THRESHOLD=100
+export NAT_CONNTRACKER_GIT_REF=master
+export NAT_CONNTRACKER_TOP_N=100

--- a/gce-production-net-3/Makefile
+++ b/gce-production-net-3/Makefile
@@ -3,19 +3,3 @@ AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 ENV_SHORT := production
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-WRITE_CONFIG_OPTS := --write-bastion --env-tail $(ENV_TAIL)
-
-.PHONY: default
-default: hello
-
-CONFIG_FILES := \
-	config/bastion.env \
-	config/gce-workers-$(ENV_SHORT).json \
-	config/worker-com.env \
-	config/worker-org.env
-
-.PHONY: .config
-.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
-
-$(CONFIG_FILES): config/.written config/.gce-keys-written

--- a/gce-production-net-3/main.tf
+++ b/gce-production-net-3/main.tf
@@ -10,10 +10,24 @@ variable "gce_bastion_image" {
   default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/bastion-1519767738-74530dd"
 }
 
+variable "gce_heroku_org" {}
+
+variable "gce_nat_image" {
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
+}
+
 variable "github_users" {}
 
 variable "index" {
   default = 3
+}
+
+variable "nat_conntracker_src_ignore" {
+  type = "list"
+}
+
+variable "nat_conntracker_dst_ignore" {
+  type = "list"
 }
 
 variable "project" {
@@ -53,13 +67,21 @@ provider "heroku" {}
 module "gce_net" {
   source = "../modules/gce_net"
 
-  bastion_config                = "${file("config/bastion.env")}"
-  bastion_image                 = "${var.gce_bastion_image}"
-  deny_target_ip_ranges         = ["${var.deny_target_ip_ranges}"]
-  env                           = "${var.env}"
+  bastion_config        = "${file("config/bastion.env")}"
+  bastion_image         = "${var.gce_bastion_image}"
+  deny_target_ip_ranges = ["${var.deny_target_ip_ranges}"]
+  env                   = "${var.env}"
+
   github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
+  nat_config                    = "${file("config/nat.env")}"
+  nat_conntracker_config        = "${file("nat-conntracker.env")}"
+  nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
+  nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
   nat_count_per_zone            = 1
+  nat_image                     = "${var.gce_nat_image}"
+  nat_machine_type              = "n1-standard-4"
   project                       = "${var.project}"
   public_subnet_cidr_range      = "10.10.1.0/24"
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"

--- a/gce-production-net-3/nat-conntracker.env
+++ b/gce-production-net-3/nat-conntracker.env
@@ -1,0 +1,4 @@
+export NAT_CONNTRACKER_CONNTRACK_ARGS=-E+conntrack+--output+xml+--event-mask+NEW+--buffer-size+25000000
+export NAT_CONNTRACKER_CONN_THRESHOLD=100
+export NAT_CONNTRACKER_GIT_REF=master
+export NAT_CONNTRACKER_TOP_N=100

--- a/gce-staging-1/Makefile
+++ b/gce-staging-1/Makefile
@@ -1,4 +1,7 @@
-include $(shell git rev-parse --show-toplevel)/gce.mk
+TRAVIS_BUILD_COM_HOST := build-staging.travis-ci.com
+TRAVIS_BUILD_ORG_HOST := build-staging.travis-ci.org
+JOB_BOARD_HOST := job-board-staging.travis-ci.com
+AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
+AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 
-.PHONY: .config
-.config: $(ENV_NAME).auto.tfvars
+include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-staging-net-1/Makefile
+++ b/gce-staging-net-1/Makefile
@@ -1,21 +1,8 @@
 AMQP_URL_COM_VARNAME := CLOUDAMQP_URL
 AMQP_URL_ORG_VARNAME := CLOUDAMQP_GRAY_URL
 ENV_SHORT := staging
+JOB_BOARD_HOST := job-board-staging.travis-ci.com
+TRAVIS_BUILD_COM_HOST := build-staging.travis-ci.com
+TRAVIS_BUILD_ORG_HOST := build-staging.travis-ci.org
 
 include $(shell git rev-parse --show-toplevel)/gce.mk
-
-WRITE_CONFIG_OPTS := --write-bastion --env-tail $(ENV_TAIL)
-
-.PHONY: default
-default: hello
-
-CONFIG_FILES := \
-	config/bastion.env \
-	config/gce-workers-$(ENV_SHORT).json \
-	config/worker-com.env \
-	config/worker-org.env
-
-.PHONY: .config
-.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
-
-$(CONFIG_FILES): config/.written config/.gce-keys-written

--- a/gce-staging-net-1/main.tf
+++ b/gce-staging-net-1/main.tf
@@ -6,12 +6,29 @@ variable "env" {
   default = "staging"
 }
 
+variable "latest_docker_image_gesund" {}
+variable "latest_docker_image_nat_conntracker" {}
 variable "latest_gce_bastion_image" {}
+
+variable "gce_heroku_org" {}
+
+variable "gce_nat_image" {
+  # TODO: replace with vanilla ubuntu bionic image
+  default = "https://www.googleapis.com/compute/v1/projects/eco-emissary-99515/global/images/tfw-1520467760-573cd26"
+}
 
 variable "github_users" {}
 
 variable "index" {
   default = 1
+}
+
+variable "nat_conntracker_src_ignore" {
+  type = "list"
+}
+
+variable "nat_conntracker_dst_ignore" {
+  type = "list"
 }
 
 variable "project" {
@@ -51,17 +68,31 @@ provider "heroku" {}
 module "gce_net" {
   source = "../modules/gce_net"
 
-  bastion_config                = "${file("config/bastion.env")}"
-  bastion_image                 = "${var.latest_gce_bastion_image}"
-  deny_target_ip_ranges         = ["${var.deny_target_ip_ranges}"]
-  env                           = "${var.env}"
+  bastion_config        = "${file("config/bastion.env")}"
+  bastion_image         = "${var.latest_gce_bastion_image}"
+  deny_target_ip_ranges = ["${var.deny_target_ip_ranges}"]
+  env                   = "${var.env}"
+
+  # TODO: replace with var.latest_docker_image_gesund
+  gesund_self_image = "travisci/gesund:0.1.0"
+
   github_users                  = "${var.github_users}"
+  heroku_org                    = "${var.gce_heroku_org}"
   index                         = "${var.index}"
+  nat_config                    = "${file("config/nat.env")}"
+  nat_conntracker_config        = "${file("nat-conntracker.env")}"
+  nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
+  nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
   nat_count_per_zone            = 2
+  nat_image                     = "${var.gce_nat_image}"
+  nat_machine_type              = "g1-small"
   project                       = "${var.project}"
   rigaer_strasse_8_ipv4         = "${var.rigaer_strasse_8_ipv4}"
   syslog_address                = "${var.syslog_address_com}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+
+  nat_conntracker_redis_plan = "hobby-dev"
+  nat_conntracker_self_image = "${var.latest_docker_image_nat_conntracker}"
 }
 
 output "gce_network_main" {

--- a/gce-staging-net-1/nat-conntracker.env
+++ b/gce-staging-net-1/nat-conntracker.env
@@ -1,0 +1,4 @@
+export NAT_CONNTRACKER_CONNTRACK_ARGS=-E+conntrack+--output+xml+--event-mask+NEW+--buffer-size+25000000
+export NAT_CONNTRACKER_CONN_THRESHOLD=50
+export NAT_CONNTRACKER_GIT_REF=master
+export NAT_CONNTRACKER_TOP_N=10

--- a/gce.mk
+++ b/gce.mk
@@ -2,3 +2,40 @@ TOP := $(shell git rev-parse --show-toplevel)
 
 include $(TOP)/terraform-common.mk
 include $(TOP)/trvs.mk
+
+WRITE_CONFIG_OPTS := --write-bastion --write-nat --env-tail $(ENV_TAIL)
+
+.PHONY: default
+default: hello
+
+CONFIG_FILES := \
+	config/bastion.env \
+	config/gce-workers-$(ENV_SHORT).json \
+	config/worker-com.env \
+	config/worker-org.env \
+	$(NATBZ2)
+
+.PHONY: .config
+.config: $(CONFIG_FILES) $(ENV_NAME).auto.tfvars
+
+$(CONFIG_FILES): config/.written config/.gce-keys-written
+
+# Imports network resources from a GCE project that used a single terraform
+# graph to manage network resources and workers into a separate network-only
+# graph a la "gce-staging-net-1" for "gce-staging-1".  This target is intended
+# to be run within a given "net" graph directory such as "gce-production-net-5".
+.PHONY: import-net
+import-net:
+	$(TOP)/bin/gce-import-net \
+		--env $(ENV_SHORT) \
+		--index $(shell awk -F- '{ print $$NF }' <<<$(ENV_NAME)) \
+		--project $(shell $(TOP)/bin/lookup-gce-project $(ENV_NAME)) \
+		--terraform $(TERRAFORM)
+
+# Removes state references from a GCE project that has migrated network
+# resources to a network-only terraform graph (see `import-net` above). This
+# target is intended to be run within a given "non-net" graph directory such as
+# "gce-production-5".
+.PHONY: export-net
+export-net:
+	$(TOP)/bin/gce-export-net --terraform $(TERRAFORM)

--- a/modules/gce_net/firewall.tf
+++ b/modules/gce_net/firewall.tf
@@ -1,3 +1,4 @@
+
 resource "google_compute_firewall" "allow_main_ssh" {
   name          = "allow-main-ssh"
   network       = "${google_compute_network.main.name}"
@@ -50,7 +51,7 @@ resource "google_compute_firewall" "allow_public_icmp" {
   name          = "allow-public-icmp"
   network       = "${google_compute_network.main.name}"
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["bastion"]
+  target_tags   = ["nat", "bastion"]
 
   project = "${var.project}"
 
@@ -74,6 +75,23 @@ resource "google_compute_firewall" "allow_internal" {
   }
 }
 
+resource "google_compute_firewall" "allow_jobs_nat" {
+  name    = "allow-jobs-nat"
+  network = "${google_compute_network.main.name}"
+  project = "${var.project}"
+
+  source_ranges = [
+    "${google_compute_subnetwork.jobs_org.ip_cidr_range}",
+    "${google_compute_subnetwork.jobs_com.ip_cidr_range}",
+  ]
+
+  target_tags = ["nat"]
+
+  allow {
+    protocol = "all"
+  }
+}
+
 resource "google_compute_firewall" "deny_target_ip" {
   name    = "deny-target-ip"
   network = "${google_compute_network.main.name}"
@@ -89,3 +107,4 @@ resource "google_compute_firewall" "deny_target_ip" {
     protocol = "all"
   }
 }
+

--- a/modules/gce_net/firewall.tf
+++ b/modules/gce_net/firewall.tf
@@ -1,4 +1,3 @@
-
 resource "google_compute_firewall" "allow_main_ssh" {
   name          = "allow-main-ssh"
   network       = "${google_compute_network.main.name}"
@@ -107,4 +106,3 @@ resource "google_compute_firewall" "deny_target_ip" {
     protocol = "all"
   }
 }
-

--- a/modules/gce_net/nat-cloud-config.yml.tpl
+++ b/modules/gce_net/nat-cloud-config.yml.tpl
@@ -1,0 +1,33 @@
+#cloud-config
+# vim:filetype=yaml
+
+write_files:
+- content: '${base64encode(docker_env)}'
+  encoding: b64
+  owner: 'root:root'
+  path: /etc/default/docker
+- content: '${base64encode(gesund_config)}'
+  encoding: b64
+  path: /etc/default/gesund
+- content: '${base64encode(github_users_env)}'
+  encoding: b64
+  path: /etc/default/github-users
+- content: '${base64encode(nat_config)}'
+  encoding: b64
+  path: /etc/default/nat
+- content: '${base64encode(nat_conntracker_config)}'
+  encoding: b64
+  path: /etc/default/nat-conntracker
+- content: '${base64encode(cloud_init_bash)}'
+  encoding: b64
+  path: /var/lib/cloud/scripts/per-boot/99-nat-cloud-init
+  permissions: '0750'
+- content: '${filebase64("${assets}/nat.tar.bz2")}'
+  encoding: b64
+  path: /var/tmp/nat.tar.bz2
+- content: '${base64encode(syslog_address)}'
+  encoding: b64
+  path: /var/tmp/travis-run.d/syslog-address
+
+runcmd:
+- [/var/lib/cloud/scripts/per-boot/99-nat-cloud-init]

--- a/modules/gce_net/nat-cloud-init.bash
+++ b/modules/gce_net/nat-cloud-init.bash
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# vim:filetype=sh
+set -o errexit
+set -o pipefail
+
+main() {
+  : "${ETCDIR:=/etc}"
+  : "${TMPDIR:=/var/tmp}"
+  : "${USRLOCAL:=/usr/local}"
+  : "${VARTMP:=/var/tmp}"
+
+  export DEBIAN_FRONTEND=noninteractive
+  __disable_unfriendly_services
+  __install_tfw
+
+  eval "$(tfw printenv nat)"
+
+  __expand_nat_tbz2
+  __setup_gesund
+  __write_librato_config "${GCE_NAT_LIBRATO_EMAIL}" "${GCE_NAT_LIBRATO_TOKEN}"
+  __setup_nat_forwarding
+  __setup_nat_conntracker
+}
+
+__disable_unfriendly_services() {
+  systemctl stop apt-daily-upgrade || true
+  systemctl disable apt-daily-upgrade || true
+  systemctl stop apt-daily || true
+  systemctl disable apt-daily || true
+  systemctl stop apparmor || true
+  systemctl disable apparmor || true
+  systemctl reset-failed
+}
+
+__install_tfw() {
+  apt-get update -yqq
+  apt-get install -yqq curl make
+
+  rm -rf "${TMPDIR}/tfw-install"
+  mkdir -p "${TMPDIR}/tfw-install"
+  curl -sSL https://api.github.com/repos/travis-ci/tfw/tarball/master |
+    tar -C "${TMPDIR}/tfw-install" --strip-components=1 -xzf -
+  make -C "${TMPDIR}/tfw-install" install PREFIX="${USRLOCAL}"
+}
+
+__write_librato_config() {
+  if [[ ! "${1}" || ! "${2}" ]]; then
+    return
+  fi
+
+  apt-get update -y
+  apt-get install -y collectd collectd-utils
+
+  mkdir -p "${ETCDIR}/collectd/collectd.conf.d"
+
+  local hostname_tmpl="${VARTMP}/travis-run.d/instance-hostname.tmpl"
+  local hostname_setting
+  if [[ -f "${hostname_tmpl}" ]]; then
+    local region_zone hostname_rendered
+    region_zone="$(__fetch_region_zone)"
+    hostname_rendered="$(
+      sed "s/___REGION_ZONE___/${region_zone}/g" <"${hostname_tmpl}"
+    )"
+    hostname_setting="Hostname ${hostname_rendered}"
+  fi
+
+  cat >"${ETCDIR}/collectd/collectd.conf.d/librato.conf" <<EOF
+# Written by cloud-init $(date -u) :heart:
+${hostname_setting}
+LoadPlugin write_http
+
+<Plugin "write_http">
+  <Node "Librato">
+    URL "https://collectd.librato.com/v1/measurements"
+    User "${1}"
+    Password "${2}"
+    Format "JSON"
+  </Node>
+</Plugin>
+EOF
+
+  systemctl enable collectd || true
+  systemctl restart collectd
+}
+
+__expand_nat_tbz2() {
+  local nattbz2="${VARTMP}/nat.tar.bz2"
+
+  if [[ ! -f "${nattbz2}" ]]; then
+    return
+  fi
+
+  tar --no-same-permissions --strip-components=1 -C / -xvf "${nattbz2}"
+}
+
+__setup_nat_forwarding() {
+  local pub_iface
+  pub_iface="$(__find_public_interface)"
+
+  sysctl -w net.ipv4.ip_forward=1
+
+  iptables -t nat -S POSTROUTING | grep -v 172. | if ! grep -q MASQUERADE; then
+    iptables -t nat -I POSTROUTING -o "${pub_iface}" -j MASQUERADE
+  fi
+
+  iptables -S FORWARD | grep -v docker |
+    if ! grep -qE 'conntrack.+RELATED,ESTABLISHED'; then
+      iptables -I FORWARD -o "${pub_iface}" \
+        -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    fi
+
+  iptables -P INPUT ACCEPT
+  iptables -P FORWARD ACCEPT
+  iptables -P OUTPUT ACCEPT
+  iptables -t nat -P PREROUTING ACCEPT
+  iptables -t nat -P INPUT ACCEPT
+  iptables -t nat -P OUTPUT ACCEPT
+  iptables -t nat -P POSTROUTING ACCEPT
+}
+
+__find_public_interface() {
+  local iface=ens4
+  iface="$(ip -o addr show | grep -vE 'inet (172|127)\.' | grep -v inet6 |
+    awk '{ print $2 }' | grep -v '^lo$' | head -n 1)"
+  echo "${iface:-ens4}"
+}
+
+__setup_nat_conntracker() {
+  eval "$(tfw printenv nat-conntracker)"
+  tfw extract nat-conntracker "${NAT_CONNTRACKER_SELF_IMAGE}"
+
+  apt-get update -y
+  apt-get install -y fail2ban conntrack
+
+  systemctl enable nat-conntracker || true
+  systemctl start nat-conntracker || true
+
+  systemctl enable fail2ban || true
+  systemctl start fail2ban || true
+
+  local ncc="${VARTMP}/nat-conntracker-confs"
+
+  if [[ ! -d "${ncc}" ]]; then
+    return
+  fi
+
+  cp -v "${ncc}/fail2ban-action-iptables-blocktype.local" \
+    "${ETCDIR}/fail2ban/action.d/iptables-blocktype.local"
+
+  cp -v "${ncc}/fail2ban-filter-nat-conntracker.conf" \
+    "${ETCDIR}/fail2ban/filter.d/nat-conntracker.conf"
+
+  cp -v "${ncc}/fail2ban-jail-nat-conntracker.conf" \
+    "${ETCDIR}/fail2ban/jail.d/nat-conntracker.conf"
+
+  cp -v "${ncc}/fail2ban.local" \
+    "${ETCDIR}/fail2ban/fail2ban.local"
+
+  systemctl restart fail2ban || true
+}
+
+__setup_gesund() {
+  eval "$(tfw printenv gesund)"
+  tfw extract gesund "${GESUND_SELF_IMAGE}"
+
+  systemctl enable gesund || true
+  systemctl start gesund || true
+}
+
+__fetch_region_zone() {
+  curl -s -H 'Metadata-Flavor: Google' \
+    http://metadata.google.internal/computeMetadata/v1/instance/zone |
+    awk -F/ '{ print $NF }'
+}
+
+main "${@}"

--- a/modules/gce_net/nat.tf
+++ b/modules/gce_net/nat.tf
@@ -28,7 +28,6 @@ resource "google_compute_router" "nat" {
   name    = "router"
   region  = "${google_compute_subnetwork.public.region}"
   network = "${google_compute_network.main.self_link}"
-  project = "${var.project}"
 
   bgp {
     asn = 64514
@@ -42,7 +41,6 @@ resource "google_compute_router_nat" "nat" {
   nat_ip_allocate_option             = "MANUAL_ONLY"
   nat_ips                            = ["${google_compute_address.nat.*.self_link}"]
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
-  project                            = "${var.project}"
 
   subnetwork {
     name                    = "${google_compute_subnetwork.jobs_org.self_link}"

--- a/modules/gce_net/nat.tf
+++ b/modules/gce_net/nat.tf
@@ -24,36 +24,214 @@ resource "aws_route53_record" "nat_regional" {
   records = ["${google_compute_address.nat.*.address}"]
 }
 
-resource "google_compute_router" "nat" {
-  name    = "router"
-  region  = "${google_compute_subnetwork.public.region}"
-  network = "${google_compute_network.main.self_link}"
+resource "heroku_app" "nat_conntracker" {
+  name   = "nat-conntracker-gce-${var.env == "production" ? "prod" : var.env}-${var.index}"
+  region = "us"
 
-  bgp {
-    asn = 64514
+  organization {
+    name = "${var.heroku_org}"
+  }
+
+  config_vars {
+    MANAGED_VIA = "github.com/travis-ci/terraform-config"
   }
 }
 
-resource "google_compute_router_nat" "nat" {
-  name                               = "nat-1"
-  router                             = "${google_compute_router.nat.name}"
-  region                             = "${var.region}"
-  nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = ["${google_compute_address.nat.*.self_link}"]
-  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+resource "heroku_addon" "nat_conntracker_redis" {
+  app  = "${heroku_app.nat_conntracker.name}"
+  plan = "heroku-redis:${var.nat_conntracker_redis_plan}"
+}
 
-  subnetwork {
-    name                    = "${google_compute_subnetwork.jobs_org.self_link}"
-    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+data "template_file" "nat_cloud_config" {
+  template = "${file("${path.module}/nat-cloud-config.yml.tpl")}"
+
+  vars {
+    assets          = "${path.module}/../../../../assets"
+    cloud_init_bash = "${file("${path.module}/nat-cloud-init.bash")}"
+    nat_config      = "${var.nat_config}"
+    syslog_address  = "${var.syslog_address}"
+
+    github_users_env = <<EOF
+export GITHUB_USERS='${var.github_users}'
+EOF
+
+    docker_env = <<EOF
+export TRAVIS_DOCKER_DISABLE_DIRECT_LVM=1
+EOF
+
+    gesund_config = <<EOF
+### in-line
+export GESUND_SELF_IMAGE=${var.gesund_self_image}
+EOF
+
+    nat_conntracker_config = <<EOF
+### nat-conntracker.env
+${var.nat_conntracker_config}
+
+### in-line
+export NAT_CONNTRACKER_REDIS_ADDON_NAME=${heroku_addon.nat_conntracker_redis.name}
+export NAT_CONNTRACKER_REDIS_APP_NAME=${heroku_app.nat_conntracker.name}
+export NAT_CONNTRACKER_REDIS_URL=${lookup(heroku_app.nat_conntracker.all_config_vars, "REDIS_URL")}
+export NAT_CONNTRACKER_SELF_IMAGE=${var.nat_conntracker_self_image}
+EOF
+  }
+}
+
+resource "google_compute_instance_template" "nat" {
+  count          = "${length(var.nat_zones) * var.nat_count_per_zone}"
+  name           = "${var.env}-${var.index}-${element(var.nat_names, count.index)}-template-${substr(sha256("${var.nat_image}${data.template_file.nat_cloud_config.rendered}"), 0, 7)}"
+  machine_type   = "${var.nat_machine_type}"
+  can_ip_forward = true
+  region         = "${var.region}"
+  tags           = ["nat", "${var.env}"]
+  project        = "${var.project}"
+
+  labels {
+    environment = "${var.env}"
   }
 
-  subnetwork {
-    name                    = "${google_compute_subnetwork.jobs_com.self_link}"
-    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
   }
 
-  log_config {
-    filter = "TRANSLATIONS_ONLY"
-    enable = true
+  disk {
+    auto_delete  = true
+    boot         = true
+    source_image = "${var.nat_image}"
+  }
+
+  network_interface {
+    subnetwork = "${google_compute_subnetwork.public.self_link}"
+
+    access_config {
+      nat_ip = "${google_compute_address.nat.*.address[count.index]}"
+    }
+  }
+
+  metadata {
+    "block-project-ssh-keys" = "true"
+    "user-data"              = "${data.template_file.nat_cloud_config.rendered}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_http_health_check" "nat" {
+  name                = "nat-health-check"
+  request_path        = "/health-check"
+  check_interval_sec  = 30
+  healthy_threshold   = 1
+  unhealthy_threshold = 5
+  project             = "${var.project}"
+}
+
+resource "google_compute_firewall" "allow_nat_health_check" {
+  name        = "allow-nat-health-check"
+  network     = "${google_compute_network.main.name}"
+  project     = "${var.project}"
+  target_tags = ["nat"]
+
+  source_ranges = ["${var.gce_health_check_source_ranges}"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [80]
+  }
+}
+
+resource "google_compute_instance_group_manager" "nat" {
+  provider = "google-beta"
+  count    = "${length(var.nat_zones) * var.nat_count_per_zone}"
+
+  base_instance_name = "${var.env}-${var.index}-${element(var.nat_names, count.index)}"
+  name               = "${element(var.nat_names, count.index)}"
+  target_size        = 1
+  zone               = "${var.region}-${element(var.nat_zones, count.index)}"
+
+  version {
+    name              = "${var.env}-${var.index}-nat-default"
+    instance_template = "${google_compute_instance_template.nat.*.self_link[count.index]}"
+  }
+
+  named_port {
+    name = "http"
+    port = 80
+  }
+
+  auto_healing_policies {
+    health_check      = "${google_compute_http_health_check.nat.self_link}"
+    initial_delay_sec = 300
+  }
+}
+
+data "external" "nats_by_zone" {
+  program = ["${path.module}/../../bin/gcloud-nats-by-zone"]
+
+  query {
+    zones   = "${join(",", var.nat_zones)}"
+    region  = "${var.region}"
+    project = "${var.project}"
+    count   = "${length(var.nat_zones) * var.nat_count_per_zone}"
+  }
+
+  depends_on = ["google_compute_instance_group_manager.nat"]
+}
+
+resource "google_compute_route" "nat" {
+  count                  = "${length(var.nat_zones) * var.nat_count_per_zone}"
+  dest_range             = "0.0.0.0/0"
+  name                   = "${element(var.nat_names, count.index)}"
+  network                = "${google_compute_network.main.self_link}"
+  next_hop_instance      = "${data.external.nats_by_zone.result[var.nat_names[count.index]]}"
+  next_hop_instance_zone = "${var.region}-${element(var.nat_zones, count.index / var.nat_count_per_zone)}"
+  priority               = 800
+  tags                   = ["no-ip"]
+  project                = "${var.project}"
+
+  lifecycle {
+    # NOTE: the `next_hop_instance` is provided by `data.external.nats_by_zone`,
+    # which does not play nicely with graph change detection.  Rather than
+    # constantly re-creating these route resources, we ignore the change to
+    # `next_hop_instance`.  Any changes in the instances within the relevant
+    # instance groups will require a manual `taint` of *this* resource in order
+    # for the route to correctly resolve.  See the following URL for details:
+    # https://www.terraform.io/docs/commands/taint.html#example-tainting-a-resource-within-a-module
+    ignore_changes = ["next_hop_instance"]
+  }
+}
+
+data "template_file" "nat_rolling_updater_config" {
+  template = <<EOF
+export GCE_NAT_PROJECT='${var.project}'
+export GCE_NAT_REGION='${var.region}'
+export GCE_NAT_GROUPS='${join(",", google_compute_instance_group_manager.nat.*.name)}'
+EOF
+}
+
+resource "local_file" "nat_rolling_updater_config" {
+  content  = "${data.template_file.nat_rolling_updater_config.rendered}"
+  filename = "${path.cwd}/config/nat-rolling-updater-${var.env}-${var.index}.env"
+
+  provisioner "local-exec" {
+    command = "chmod 0644 ${local_file.nat_rolling_updater_config.filename}"
+  }
+}
+
+resource "null_resource" "nat_conntracker_dynamic_config" {
+  triggers {
+    dst_ignore = "${sha256(join("", sort(var.nat_conntracker_dst_ignore)))}"
+    src_ignore = "${sha256(join("", sort(var.nat_conntracker_src_ignore)))}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+${path.module}/../../bin/nat-conntracker-configure \
+    --app "${heroku_app.nat_conntracker.name}" \
+    --dst-ignore "${join(",", sort(var.nat_conntracker_dst_ignore))}" \
+    --src-ignore "${join(",", sort(var.nat_conntracker_src_ignore))}"
+EOF
   }
 }

--- a/modules/gce_net/variables.tf
+++ b/modules/gce_net/variables.tf
@@ -115,4 +115,3 @@ variable "build_com_subnet_cidr_range" {
 variable "build_org_subnet_cidr_range" {
   default = "10.10.8.0/22"
 }
-

--- a/modules/gce_net/variables.tf
+++ b/modules/gce_net/variables.tf
@@ -12,11 +12,49 @@ variable "deny_target_ip_ranges" {
 
 variable "env" {}
 
+variable "gce_health_check_source_ranges" {
+  default = [
+    "130.211.0.0/22",
+    "35.191.0.0/16",
+  ]
+}
+
+variable "gesund_self_image" {
+  default = "travisci/gesund:0.1.0"
+}
+
 variable "github_users" {}
+variable "heroku_org" {}
 variable "index" {}
+variable "nat_config" {}
+variable "nat_conntracker_config" {}
+
+variable "nat_conntracker_dst_ignore" {
+  type    = "list"
+  default = ["private"]
+}
+
+variable "nat_conntracker_src_ignore" {
+  type    = "list"
+  default = ["127.0.0.0/8", "10.10.0.0/16"]
+}
+
+variable "nat_conntracker_self_image" {
+  default = "travisci/nat-conntracker:0.5.0"
+}
+
+variable "nat_conntracker_redis_plan" {
+  default = "premium-0"
+}
 
 variable "nat_count_per_zone" {
   default = 1
+}
+
+variable "nat_image" {}
+
+variable "nat_machine_type" {
+  default = "custom-1-2048"
 }
 
 variable "nat_zones" {
@@ -69,3 +107,12 @@ variable "jobs_com_subnet_cidr_range" {
 variable "gke_cluster_subnet_cidr_range" {
   default = "10.40.0.0/16"
 }
+
+variable "build_com_subnet_cidr_range" {
+  default = "10.10.12.0/22"
+}
+
+variable "build_org_subnet_cidr_range" {
+  default = "10.10.8.0/22"
+}
+

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -14,6 +14,7 @@ JOB_BOARD_HOST ?= job-board.travis-ci.com
 AMQP_URL_COM_VARNAME ?= AMQP_URL
 AMQP_URL_ORG_VARNAME ?= AMQP_URL
 TOP := $(shell git rev-parse --show-toplevel)
+NATBZ2 := $(TOP)/assets/nat.tar.bz2
 
 PROD_TF_VERSION := v0.11.13
 TERRAFORM := $(TF_INSTALLATION_PREFIX)/terraform-$(PROD_TF_VERSION)
@@ -106,6 +107,9 @@ TAR := LC_ALL=C $(TAR) \
       --numeric-owner \
       --sort=name \
       -cj
+
+$(NATBZ2): tar $(wildcard $(TOP)/assets/nat/**/*)
+	$(TAR) -C $(TOP)/assets -f $(NATBZ2) nat
 
 $(TFSTATE):
 	$(TERRAFORM) init


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
#679 introduced Cloud NAT instead of VMs with NAT gateways, this caused the performance of the NAT gateways to decrease dramatically.

As a bonus, I've fixed the naming on prod-1 (re-import the NAT IPs), this was necessary as `bin/gcloud-nats-by-zone` went haywire on the naming scheme.

## What approach did you choose and why?
Revert a bunch of commits from #679 and fix the Makefile cleanup done by a commit in #678.

## How can you test this?
Ran against staging and prod-3, executed on prod-1 already, prod-2 follows this afternoon.

## What feedback would you like, if any?
Shout out if you have something to say!