### PR TITLE
Increase NATs and max k8s nodes on prod-3

### DIFF
--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -90,7 +90,8 @@ module "gke_cluster_1" {
   gke_network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   gke_subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   k8s_default_namespace = "${var.k8s_default_namespace}"
-  k8s_max_node_count    = 20
+  k8s_min_node_count    = 4
+  k8s_max_node_count    = 50
 }
 
 output "workers_service_account_emails" {

--- a/gce-production-net-3/main.tf
+++ b/gce-production-net-3/main.tf
@@ -79,7 +79,7 @@ module "gce_net" {
   nat_conntracker_config        = "${file("nat-conntracker.env")}"
   nat_conntracker_dst_ignore    = ["${var.nat_conntracker_dst_ignore}"]
   nat_conntracker_src_ignore    = ["${var.nat_conntracker_src_ignore}"]
-  nat_count_per_zone            = 1
+  nat_count_per_zone            = 2
   nat_image                     = "${var.gce_nat_image}"
   nat_machine_type              = "n1-standard-4"
   project                       = "${var.project}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Our quota's have been increased, this will allow us to add more NAT machines and increase nodes/workers on prod-3

## What approach did you choose and why?
Increase the number of NATs: this should keep the existing IPs around.
NOTE: We should first create the new IPs (`terraform plan -target ...`) and communicate them

This also increases the max. nodes for GKE, the same as we have on the other projects.

## How can you test this?
This is tested module code and already running in prod.

## What feedback would you like, if any?
Not  really.
