### PR TITLE
Correctly use new gce_kubernetes module

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -88,11 +88,13 @@ module "gke_cluster_1" {
   project           = "${var.project}"
   cluster_name      = "gce-production-1"
   pool_name         = "gce-production-1"
+  region            = "us-central1"
   network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"
   min_node_count    = 4
   max_node_count    = 50
+  node_locations    = ["us-central1-a", "us-central1-c", "us-central1-f"]
   node_pool_tags    = ["gce-workers"]
 }
 

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -88,11 +88,13 @@ module "gke_cluster_1" {
   project           = "${var.project}"
   cluster_name      = "gce-production-2"
   pool_name         = "gce-production-2"
+  region            = "us-central1"
   network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"
   min_node_count    = 4
   max_node_count    = 50
+  node_locations    = ["us-central1-a", "us-central1-c", "us-central1-b"]
   node_pool_tags    = ["gce-workers"]
 }
 

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -88,10 +88,13 @@ module "gke_cluster_1" {
   project           = "${var.project}"
   cluster_name      = "gce-production-3"
   pool_name         = "gce-production-3"
+  region            = "us-central1"
   network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"
-  max_node_count    = 20
+  min_node_count    = 4
+  max_node_count    = 50
+  node_locations    = ["us-central1-a", "us-central1-c", "us-central1-b"]
   node_pool_tags    = ["gce-workers"]
 }
 

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -88,6 +88,7 @@ module "gke_cluster_1" {
   project           = "${var.project}"
   cluster_name      = "gce-staging-1"
   pool_name         = "gce-staging-1"
+  region            = "us-central1-a"
   network           = "${data.terraform_remote_state.vpc.gce_network_main}"
   subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"

--- a/modules/gce_kubernetes/cluster.tf
+++ b/modules/gce_kubernetes/cluster.tf
@@ -25,7 +25,7 @@ resource "google_container_cluster" "gke_cluster" {
   private_cluster_config {
     enable_private_endpoint = "${var.enable_private_endpoint}"
     enable_private_nodes    = "${var.enable_private_nodes}"
-    master_ipv4_cidr_block  = "172.16.0.0/28"
+    master_ipv4_cidr_block  = "${var.private_master_ipv4_cidr_block}"
   }
 
   master_authorized_networks_config {

--- a/modules/gce_kubernetes/variables.tf
+++ b/modules/gce_kubernetes/variables.tf
@@ -31,9 +31,13 @@ variable "machine_type" {
 }
 
 variable "enable_private_endpoint" {
-  default = false
+  default = ""
 }
 
 variable "enable_private_nodes" {
-  default = false
+  default = ""
+}
+
+variable "private_master_ipv4_cidr_block" {
+  default = ""
 }

--- a/travis-ci-prod-services-1/modules.tf
+++ b/travis-ci-prod-services-1/modules.tf
@@ -21,9 +21,10 @@ module "kubernetes_cluster" {
   region            = "${var.region}"
   subnetwork        = "${module.networking.services_network_name}"
 
-  node_locations       = ["us-central1-b", "us-central1-c"]
-  node_pool_tags       = ["services"]
-  max_node_count       = 10
-  machine_type         = "c2-standard-4"
-  enable_private_nodes = true
+  node_locations                 = ["us-central1-b", "us-central1-c"]
+  node_pool_tags                 = ["services"]
+  max_node_count                 = 10
+  machine_type                   = "c2-standard-4"
+  enable_private_nodes           = true
+  private_master_ipv4_cidr_block = "172.16.0.0/28"
 }

--- a/travis-ci-staging-services-1/modules.tf
+++ b/travis-ci-staging-services-1/modules.tf
@@ -21,9 +21,10 @@ module "kubernetes_cluster" {
   region            = "${var.region}"
   subnetwork        = "${module.networking.services_network_name}"
 
-  node_locations       = ["us-central1-b", "us-central1-c"]
-  node_pool_tags       = ["services"]
-  max_node_count       = 10
-  machine_type         = "c2-standard-4"
-  enable_private_nodes = true
+  node_locations                 = ["us-central1-b", "us-central1-c"]
+  node_pool_tags                 = ["services"]
+  max_node_count                 = 10
+  machine_type                   = "c2-standard-4"
+  enable_private_nodes           = true
+  private_master_ipv4_cidr_block = "172.16.0.0/28"
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The introduction of a new Kubernetes module caused the creation of a new cluster on several projects (because of private networking) and was missing a few 'location' configurations.

## What approach did you choose and why?
Disable private networking for the existing clusters and add the 'location' config.

## How can you test this?
Testing can be done against staging.

## What feedback would you like, if any?
Sure.


