### PR TITLE
Replace dirty Kubernetes cluster with a new one

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -84,18 +84,21 @@ module "gce_worker_group" {
 }
 
 module "gke_cluster_1" {
-  source            = "../modules/gce_kubernetes"
-  project           = "${var.project}"
+  source = "../modules/gce_kubernetes"
+
   cluster_name      = "gce-production-1"
-  pool_name         = "gce-production-1"
-  region            = "us-central1"
-  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
-  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"
-  min_node_count    = 4
-  max_node_count    = 50
-  node_locations    = ["us-central1-a", "us-central1-c", "us-central1-f"]
-  node_pool_tags    = ["gce-workers"]
+  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  pool_name         = "default"
+  project           = "${var.project}"
+  region            = "us-central1"
+  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
+
+  node_locations = ["us-central1-b", "us-central1-c"]
+  node_pool_tags = ["gce-workers"]
+  min_node_count = 4
+  max_node_count = 50
+  machine_type   = "c2-standard-4"
 }
 
 output "workers_service_account_emails" {

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -84,18 +84,21 @@ module "gce_worker_group" {
 }
 
 module "gke_cluster_1" {
-  source            = "../modules/gce_kubernetes"
-  project           = "${var.project}"
+  source = "../modules/gce_kubernetes"
+
   cluster_name      = "gce-production-2"
-  pool_name         = "gce-production-2"
-  region            = "us-central1"
-  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
-  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"
-  min_node_count    = 4
-  max_node_count    = 50
-  node_locations    = ["us-central1-a", "us-central1-c", "us-central1-b"]
-  node_pool_tags    = ["gce-workers"]
+  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  pool_name         = "default"
+  project           = "${var.project}"
+  region            = "us-central1"
+  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
+
+  node_locations = ["us-central1-b", "us-central1-c"]
+  node_pool_tags = ["gce-workers"]
+  min_node_count = 4
+  max_node_count = 50
+  machine_type   = "c2-standard-4"
 }
 
 output "workers_service_account_emails" {

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -84,18 +84,21 @@ module "gce_worker_group" {
 }
 
 module "gke_cluster_1" {
-  source            = "../modules/gce_kubernetes"
-  project           = "${var.project}"
+  source = "../modules/gce_kubernetes"
+
   cluster_name      = "gce-production-3"
-  pool_name         = "gce-production-3"
-  region            = "us-central1"
-  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
-  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
   default_namespace = "${var.k8s_default_namespace}"
-  min_node_count    = 4
-  max_node_count    = 50
-  node_locations    = ["us-central1-a", "us-central1-c", "us-central1-b"]
-  node_pool_tags    = ["gce-workers"]
+  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  pool_name         = "default"
+  project           = "${var.project}"
+  region            = "us-central1"
+  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
+
+  node_locations = ["us-central1-b", "us-central1-c"]
+  node_pool_tags = ["gce-workers"]
+  min_node_count = 4
+  max_node_count = 50
+  machine_type   = "c2-standard-4"
 }
 
 output "workers_service_account_emails" {

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -84,20 +84,21 @@ module "gce_worker_group" {
 }
 
 module "workers_1" {
-  source            = "../modules/gce_kubernetes"
-  project           = "${var.project}"
-  cluster_name      = "workers-1"
-  pool_name         = "default"
-  region            = "us-central1"
-  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
-  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
-  default_namespace = "${var.k8s_default_namespace}"
+  source = "../modules/gce_kubernetes"
 
-  machine_type       = "c2-standard-4"
-  max_node_count     = 10
-  min_master_version = "1.14"
+  cluster_name      = "workers-1"
+  default_namespace = "${var.k8s_default_namespace}"
+  network           = "${data.terraform_remote_state.vpc.gce_network_main}"
+  pool_name         = "default"
+  project           = "${var.project}"
+  region            = "us-central1"
+  subnetwork        = "${data.terraform_remote_state.vpc.gce_subnetwork_gke_cluster}"
+
   node_locations     = ["us-central1-b", "us-central1-c"]
   node_pool_tags     = ["gce-workers"]
+  max_node_count     = 10
+  machine_type       = "c2-standard-4"
+  min_master_version = "1.14"
 }
 
 output "workers_service_account_emails" {

--- a/modules/gce_kubernetes/cluster.tf
+++ b/modules/gce_kubernetes/cluster.tf
@@ -44,8 +44,9 @@ resource "google_container_node_pool" "node_pool" {
   initial_node_count = 1
 
   node_config {
-    machine_type = "${var.machine_type}"
-    tags         = "${var.node_pool_tags}"
+    machine_type    = "${var.machine_type}"
+    tags            = "${var.node_pool_tags}"
+    service_account = "${google_service_account.cluster_service_account.email}"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
@@ -53,6 +54,10 @@ resource "google_container_node_pool" "node_pool" {
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
   }
 
   management {

--- a/modules/gce_kubernetes/service_accounts.tf
+++ b/modules/gce_kubernetes/service_accounts.tf
@@ -1,0 +1,29 @@
+resource "google_service_account" "cluster_service_account" {
+  project      = "${var.project}"
+  account_id   = "tf-gke-${var.cluster_name}"
+  display_name = "Terraform-managed service account for cluster ${var.cluster_name}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-log_writer" {
+  project = "${var.project}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cluster_service_account.email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+  project = "${var.project}"
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.cluster_service_account.email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
+  project = "${var.project}"
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account.email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account-gcr" {
+  project = "${var.project}"
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account.email}"
+}

--- a/modules/gce_net_workers/firewall.tf
+++ b/modules/gce_net_workers/firewall.tf
@@ -19,8 +19,9 @@ resource "google_compute_firewall" "allow_gke_worker_to_jobs" {
   name    = "allow-gke-workers-to-jobs"
   network = "${google_compute_network.main.name}"
 
-  source_tags = ["gce-workers"]
-  target_tags = ["testing"]
+  source_ranges = ["0.0.0.0/0"]
+  source_tags   = ["gce-workers"]
+  target_tags   = ["testing"]
 
   priority = 1000
   project  = "${var.project}"

--- a/modules/gce_worker_group/gcloud-cleanup.tf
+++ b/modules/gce_worker_group/gcloud-cleanup.tf
@@ -70,7 +70,7 @@ resource "google_service_account_key" "gcloud_cleanup" {
 resource "kubernetes_secret" "gcloud_cleanup_config" {
   metadata {
     name      = "gcloud-cleanup-terraform"
-    namespace = "${kubernetes_namespace.default.metadata.0.name}"
+    namespace = "${var.k8s_default_namespace}"
   }
 
   data = {

--- a/modules/gce_worker_group/kubernetes.tf
+++ b/modules/gce_worker_group/kubernetes.tf
@@ -1,5 +1,0 @@
-resource "kubernetes_namespace" "default" {
-  metadata {
-    name = "${var.k8s_default_namespace}"
-  }
-}

--- a/modules/gce_worker_group/workers.tf
+++ b/modules/gce_worker_group/workers.tf
@@ -7,7 +7,7 @@ module "gce_workers" {
   aws_org_id           = "${var.aws_org_id}"
   aws_org_secret       = "${var.aws_org_secret}"
   aws_org_trace_bucket = "${var.aws_org_trace_bucket}"
-  k8s_namespace        = "${kubernetes_namespace.default.metadata.0.name}"
+  k8s_namespace        = "${var.k8s_default_namespace}"
   project              = "${var.project}"
   region               = "${var.region}"
 }


### PR DESCRIPTION
Note 1: this also removes the custom creation of a "default" namespace, we
can safely remove this from the TF state on production when continuing.

Note 2: a new version of Kubernetes (1.14) is available, installed this
on staging and we should update production soon too.

## What is the problem that this PR is trying to fix?
Replace dirty Kubernetes cluster with a new one

## What approach did you choose and why?
Create a new cluster, install workers etc. and then decommission old cluster. This allows 'zero downtime' for workers.

## How can you test this?
It's staging, just run it there.

## What feedback would you like, if any?
Maybe.
